### PR TITLE
fix: stream session history reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- Streams archived history and stops at the requested entry or result limit, preventing heap exhaustion in large session directories and parallel reads.
+
 ## 0.2.0
 
 - Replaces extension-only context slicing with Pi's native, persisted `context_window` boundary.

--- a/index.ts
+++ b/index.ts
@@ -5,12 +5,21 @@
  * sparse budget reminders, rollover tools, durable notes, and history recovery.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+	appendFileSync,
+	createReadStream,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { basename, dirname, isAbsolute, join, normalize, sep } from "node:path";
+import { createInterface } from "node:readline";
 import {
 	type ExtensionAPI,
 	getAgentDir,
-	parseSessionEntries,
 	SettingsManager,
 	withFileMutationQueue,
 } from "@earendil-works/pi-coding-agent";
@@ -98,21 +107,42 @@ function flattenEntry(entry: EntryLike): string | undefined {
 	return undefined;
 }
 
-function windowEntries(entries: readonly EntryLike[]): WindowedEntry[] {
-	const windows = new Map<string, string>();
-	const result: WindowedEntry[] = [];
-	for (const entry of entries) {
-		const inheritedWindow = entry.parentId ? (windows.get(entry.parentId) ?? "initial") : "initial";
-		const windowId = entry.type === "context_window" && entry.id ? entry.id : inheritedWindow;
-		if (entry.id) windows.set(entry.id, windowId);
-		const text = flattenEntry(entry);
-		if (text && entry.id) result.push({ entry, windowId, text });
-	}
-	return result;
+function toWindowedEntry(entry: EntryLike, windows: Map<string, string>): WindowedEntry | undefined {
+	const inheritedWindow = entry.parentId ? (windows.get(entry.parentId) ?? "initial") : "initial";
+	const windowId = entry.type === "context_window" && entry.id ? entry.id : inheritedWindow;
+	if (entry.id) windows.set(entry.id, windowId);
+	const text = flattenEntry(entry);
+	return text && entry.id ? { entry, windowId, text } : undefined;
 }
 
-function parseSession(file: string): EntryLike[] {
-	return existsSync(file) ? parseSessionEntries(readFileSync(file, "utf8")) : [];
+function* windowEntries(entries: Iterable<EntryLike>): Generator<WindowedEntry> {
+	const windows = new Map<string, string>();
+	for (const entry of entries) {
+		const item = toWindowedEntry(entry, windows);
+		if (item) yield item;
+	}
+}
+
+async function* sessionWindowEntries(file: string, signal?: AbortSignal): AsyncGenerator<WindowedEntry> {
+	if (!existsSync(file)) return;
+	const stream = createReadStream(file, { encoding: "utf8", signal });
+	const lines = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+	const windows = new Map<string, string>();
+	try {
+		for await (const line of lines) {
+			let entry: EntryLike;
+			try {
+				entry = JSON.parse(line) as EntryLike;
+			} catch {
+				continue;
+			}
+			const item = toWindowedEntry(entry, windows);
+			if (item) yield item;
+		}
+	} finally {
+		lines.close();
+		stream.destroy();
+	}
 }
 
 function sessionFiles(dir: string): string[] {
@@ -360,52 +390,61 @@ export default function (pi: ExtensionAPI) {
 			limit: Type.Optional(Type.Integer({ description: "Maximum results (default 10, max 50)", minimum: 1, maximum: 50 })),
 			offset: Type.Optional(Type.Integer({ description: "Character offset for read (default 0)", minimum: 0 })),
 		}),
-		async execute(_id, params, _signal, _onUpdate, ctx) {
+		async execute(_id, params, signal, _onUpdate, ctx) {
 			const manager = ctx.sessionManager;
 			const current = windowEntries(manager.getBranch() as EntryLike[]);
-			const files = sessionFiles(manager.getSessionDir());
 
 			if (params.op === "search") {
 				const query = requireValue(params.query, "query", params.op).toLowerCase();
 				const limit = params.limit ?? 10;
-				const sources = params.all
-					? files.map((file) => ({ name: basename(file), entries: windowEntries(parseSession(file)) }))
-					: [{ name: "", entries: current }];
 				const hits: string[] = [];
-				for (const source of sources) {
-					for (const item of source.entries) {
+				const addHit = (item: WindowedEntry, source = "") => {
+					const matchIndex = item.text.toLowerCase().indexOf(query);
+					if (matchIndex === -1) return;
+					const excerptStart = Math.max(0, matchIndex - 100);
+					const excerpt = `${excerptStart ? "…" : ""}${item.text.slice(excerptStart, excerptStart + 400)}${excerptStart + 400 < item.text.length ? "…" : ""}`;
+					hits.push(
+						`${source ? `${source} ` : ""}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${item.entry.id}] ${excerpt}`,
+					);
+				};
+
+				if (params.all) {
+					files: for (const file of sessionFiles(manager.getSessionDir())) {
+						const source = basename(file);
+						for await (const item of sessionWindowEntries(file, signal)) {
+							addHit(item, source);
+							if (hits.length >= limit) break files;
+						}
+					}
+				} else {
+					for (const item of current) {
+						addHit(item);
 						if (hits.length >= limit) break;
-						const matchIndex = item.text.toLowerCase().indexOf(query);
-						if (matchIndex === -1) continue;
-						const excerptStart = Math.max(0, matchIndex - 100);
-						const excerpt = `${excerptStart ? "…" : ""}${item.text.slice(excerptStart, excerptStart + 400)}${excerptStart + 400 < item.text.length ? "…" : ""}`;
-						const prefix = source.name ? `${source.name} ` : "";
-						hits.push(
-							`${prefix}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${item.entry.id}] ${excerpt}`,
-						);
 					}
 				}
 				return textResult(hits.length ? hits.join("\n") : `No history matches "${params.query}".`);
 			}
 
 			const id = requireValue(params.id, "id", params.op);
-			const sources = [
-				{ name: "", entries: current },
-				...files.map((file) => ({ name: basename(file), entries: windowEntries(parseSession(file)) })),
-			];
-			for (const source of sources) {
-				const item = source.entries.find((candidate) => candidate.entry.id === id);
-				if (!item) continue;
+			const formatEntry = (item: WindowedEntry, source = "") => {
 				const offset = params.offset ?? 0;
 				if (offset >= item.text.length) {
 					throw new Error(`Offset ${offset} is past the end of history entry "${id}" (${item.text.length} chars).`);
 				}
 				const end = Math.min(item.text.length, offset + MAX_HANDOFF_CHARS);
-				const prefix = source.name ? `${source.name} ` : "";
 				const more = end < item.text.length ? `\nMore remains; call history read with id "${id}" and offset ${end}.` : "";
 				return textResult(
-					`${prefix}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${id}] [chars ${offset}-${end} of ${item.text.length}] ${item.text.slice(offset, end)}${more}`,
+					`${source ? `${source} ` : ""}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${id}] [chars ${offset}-${end} of ${item.text.length}] ${item.text.slice(offset, end)}${more}`,
 				);
+			};
+
+			for (const item of current) {
+				if (item.entry.id === id) return formatEntry(item);
+			}
+			for (const file of sessionFiles(manager.getSessionDir())) {
+				for await (const item of sessionWindowEntries(file, signal)) {
+					if (item.entry.id === id) return formatEntry(item, basename(file));
+				}
 			}
 			throw new Error(`No history entry with id "${id}".`);
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-headroom",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-headroom",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.84.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-headroom",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"type": "module",
 	"description": "Native no-summary context windows for a personal patched Pi, with sparse budget reminders, handoffs, notes, and history.",
 	"keywords": ["pi-package", "pi-extension", "context", "headroom"],

--- a/test/headroom.test.ts
+++ b/test/headroom.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -128,6 +128,55 @@ test("budget policy sends one reminder then requests automatic rollover", () => 
 		assert.equal(messages.length, 1);
 		assert.equal(rollovers.length, 1);
 		assert.match(rollovers[0].handoff ?? "", /Automatic context rollover/);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("history reads current entries without opening every archived session", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "pi-headroom-history-test-"));
+	try {
+		mkdirSync(join(dir, "unrelated.jsonl"));
+		const { tools } = setup();
+		const context: TestContext = {
+			cwd: process.cwd(),
+			model: { contextWindow: 100_000 },
+			sessionManager: {
+				getBranch: () => [
+					{ type: "message", id: "current", parentId: null, timestamp: "1", message: { role: "user", content: "keep me" } },
+				],
+				getSessionDir: () => dir,
+			},
+			getContextUsage: () => ({ tokens: 1000, contextWindow: 100_000, percent: 1 }),
+			newContext: () => {},
+		};
+
+		const reads = await Promise.all(
+			Array.from({ length: 5 }, () =>
+				tools
+					.get("history")!
+					.execute("id", { op: "read", id: "current" }, new AbortController().signal, () => {}, context),
+			),
+		);
+		for (const result of reads) assert.match(toolText(result), /keep me/);
+
+		rmSync(join(dir, "unrelated.jsonl"), { recursive: true });
+		writeFileSync(
+			join(dir, "archived.jsonl"),
+			[
+				"not json",
+				JSON.stringify({ type: "context_window", id: "archived-window", parentId: null, timestamp: "2", handoff: "resume" }),
+				JSON.stringify({ type: "message", id: "archived", parentId: "archived-window", timestamp: "3", message: { role: "user", content: "archived needle" } }),
+			].join("\n"),
+		);
+		const archived = await tools
+			.get("history")!
+			.execute("id", { op: "read", id: "archived" }, new AbortController().signal, () => {}, context);
+		assert.match(toolText(archived), /^archived\.jsonl .+\[window archived-window\].+archived needle/s);
+		const search = await tools
+			.get("history")!
+			.execute("id", { op: "search", query: "archived needle", all: true }, new AbortController().signal, () => {}, context);
+		assert.match(toolText(search), /^archived\.jsonl .+\[window archived-window\].+archived needle/s);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- stream archived JSONL entries instead of parsing every session into memory
- return current-branch reads before touching archived sessions
- stop cross-session searches at their result limit and honor cancellation
- add the parallel-read regression and bump the GitHub-only release to 0.2.1

## Root cause

`history read` eagerly evaluated `files.map(parseSession)` before checking the requested current-branch entry. In the TARS project that meant parsing 272 files / 4.60 GiB into a V8 heap capped at 4.19 GiB. Parallel `history` calls multiplied the allocation and crashed Pi.

## Verification

- `npm run check`
- `npm test` — 4/4
- exact final regression against v0.2.0 — expected `EISDIR` failure before the fix, pass after
- 5 parallel current reads + 5 archived reads + 5 `all=true` searches over a 64 MiB JSONL under `--max-old-space-size=256` — pass, 75 MiB JS heap
- clean package smoke install — 9 expected files
- independent correctness and ponytail reviews — no findings