### PR TITLE
fix: preserve automatic rollover continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.2
+
+- Keeps active work running across automatic rollovers without starting another response after completed work.
+- Carries the current window's user requests and constraints into automatic handoffs.
+
 ## 0.2.1
 
 - Streams archived history and stops at the requested entry or result limit, preventing heap exhaustion in large session directories and parallel reads.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The model gets stable window guidance, one near-limit checkpoint reminder, and a
 
 ## Requirement
 
-This version requires the [`native-context-windows`](https://github.com/fitchmultz/pi/tree/feature/native-context-windows) Pi patch. The official Pi package does not yet provide the native boundary used here.
+This version requires the native context-window patch on the personal [`fitchmultz/pi`](https://github.com/fitchmultz/pi) fork. The official Pi package does not yet provide the native boundary used here.
 
-Build the patched worktree, then launch its CLI directly with the extension:
+Build the patched checkout, then launch its CLI directly with the extension:
 
 ```bash
-cd /Users/mitchfultz/Projects/worktrees/pi/native-context-windows
+cd /Users/mitchfultz/Projects/pi
 npm run build
 node packages/coding-agent/dist/bundle/cli.js \
-  -e /Users/mitchfultz/Projects/worktrees/pi-headroom/native-context-windows/index.ts
+  -e /Users/mitchfultz/Projects/pi-stuff/pi-headroom/index.ts
 ```
 
 Do not use bare `pi` for this version: that still resolves to the unchanged official global install.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Do not use bare `pi` for this version: that still resolves to the unchanged offi
 2. **Sparse reminder** — one checkpoint message appears before Pi's configured compaction reserve line.
 3. **`get_context_remaining`** — returns an exact native usage reading only when the model needs it.
 4. **`new_context`** — requests an atomic rollover after the complete tool batch. An optional handoff is persisted and becomes the first state in the fresh window.
-5. **Automatic fallback** — Pi's automatic summary-compaction path is converted into the same no-summary rollover.
+5. **Automatic fallback** — Pi's automatic summary-compaction path becomes the same no-summary rollover. Active work continues, completed work stays finished, and the automatic handoff carries the current user requests and constraints.
 6. **`notes` and `history`** — durable project notes and normalized, window-aware transcript recovery remain available after rollover.
 
 Pi persists a real `context_window` session entry. Session replay, usage accounting, branch navigation, compaction, and provider input all use the same authoritative boundary; the JSONL transcript remains append-only and complete.

--- a/index.ts
+++ b/index.ts
@@ -28,8 +28,8 @@ import { Type } from "typebox";
 const REMINDER_BUFFER_TOKENS = 32_000;
 const MAX_HANDOFF_CHARS = 20_000;
 const REMINDER_TYPE = "headroom-reminder";
-const AUTO_HANDOFF =
-	"Automatic context rollover. Reload durable state with the notes tool and use history if more detail is needed before continuing the task.";
+const AUTO_HANDOFF_PREFIX =
+	"Automatic context rollover. Continue the current task without asking the user to repeat it.";
 
 type NativeContext = {
 	newContext(options?: { handoff?: string }): void;
@@ -38,9 +38,10 @@ type NativeContext = {
 type NativeExtensionAPI = {
 	on(
 		event: "session_before_compact",
-		handler: (event: { reason: "manual" | "overflow" | "threshold" }) =>
-			| { newContext: { handoff?: string } }
-			| undefined,
+		handler: (event: {
+			reason: "manual" | "overflow" | "threshold";
+			branchEntries: EntryLike[];
+		}) => { newContext: { handoff?: string } } | undefined,
 	): void;
 };
 
@@ -160,6 +161,38 @@ function currentWindowId(entries: readonly EntryLike[]): string {
 	return "initial";
 }
 
+function buildAutoHandoff(entries: readonly EntryLike[]): string {
+	let windowStart = 0;
+	let priorHandoff: string | undefined;
+	for (let i = entries.length - 1; i >= 0; i--) {
+		if (entries[i].type === "context_window") {
+			windowStart = i + 1;
+			priorHandoff = entries[i].handoff;
+			break;
+		}
+	}
+	const userMessages = entries
+		.slice(windowStart)
+		.filter((entry) => entry.type === "message" && entry.message?.role === "user")
+		.map((entry) => entry.message ?? {});
+	const requests = userMessages
+		.map((message) => textOf(message).trim())
+		.filter(Boolean)
+		.map((text, index) => `[user ${index + 1}]\n${text}`)
+		.join("\n\n");
+	if (userMessages.length === 0) return priorHandoff || AUTO_HANDOFF_PREFIX;
+	if (!requests) return AUTO_HANDOFF_PREFIX;
+
+	const header = `${AUTO_HANDOFF_PREFIX}\n\nUser requests and constraints from the previous window:\n`;
+	const available = MAX_HANDOFF_CHARS - header.length;
+	if (requests.length <= available) return `${header}${requests}`;
+
+	const omitted = "\n\n… middle user messages omitted …\n\n";
+	const firstLength = Math.floor((available - omitted.length) / 2);
+	const lastLength = available - omitted.length - firstLength;
+	return `${header}${requests.slice(0, firstLength)}${omitted}${requests.slice(-lastLength)}`;
+}
+
 function hasReminder(entries: readonly EntryLike[], windowId: string): boolean {
 	return entries.some(
 		(entry) =>
@@ -190,7 +223,7 @@ function buildGuidance(cwd: string, contextWindow: number | undefined): string {
 Context windows are finite. Use get_context_remaining when an exact reading matters; routine turns do not include a changing meter.
 One checkpoint reminder appears before the automatic rollover line (${deadline}). Save durable state with notes or pass a concise handoff to new_context.
 new_context starts a genuinely fresh Pi context after the complete tool batch. Earlier conversation remains in the session transcript and is recoverable with history.
-If the fallback line is reached, Pi starts a fresh window without generating a compaction summary. After any rollover, reload notes/history instead of guessing.`;
+If the fallback line is reached, Pi carries the current user requests and constraints into a fresh window without generating a compaction summary. Active work continues automatically; a completed answer resets quietly.`;
 }
 
 export default function (pi: ExtensionAPI) {
@@ -220,7 +253,7 @@ export default function (pi: ExtensionAPI) {
 		const reminded = hasReminder(branch, windowId);
 
 		if (usage.tokens >= rolloverAt && reminded) {
-			nativeContext(ctx).newContext({ handoff: AUTO_HANDOFF });
+			nativeContext(ctx).newContext({ handoff: buildAutoHandoff(branch) });
 			return;
 		}
 
@@ -239,7 +272,7 @@ export default function (pi: ExtensionAPI) {
 	// Last-resort conversion of Pi's automatic summary path into the same hard rollover.
 	(pi as unknown as NativeExtensionAPI).on("session_before_compact", (event) => {
 		if (event.reason === "manual") return;
-		return { newContext: { handoff: AUTO_HANDOFF } };
+		return { newContext: { handoff: buildAutoHandoff(event.branchEntries) } };
 	});
 
 	pi.registerTool({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-headroom",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-headroom",
-			"version": "0.2.1",
+			"version": "0.2.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.84.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-headroom",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"type": "module",
 	"description": "Native no-summary context windows for a personal patched Pi, with sparse budget reminders, handoffs, notes, and history.",
 	"keywords": ["pi-package", "pi-extension", "context", "headroom"],

--- a/test/headroom.test.ts
+++ b/test/headroom.test.ts
@@ -65,12 +65,24 @@ test("new_context returns a native atomic handoff and no context hook is registe
 		.execute("id", { handoff: "continue here" }, new AbortController().signal, () => {}, context);
 	assert.deepEqual(result.newContext, { handoff: "continue here" });
 	assert.equal(handlers.get("session_before_compact")!({ reason: "manual" }, context), undefined);
-	assert.match(
+	const automaticHandoff = (branchEntries: Record<string, unknown>[]) =>
 		(
-			handlers.get("session_before_compact")!({ reason: "threshold" }, context) as {
-				newContext: { handoff: string };
-			}
-		).newContext.handoff,
+			handlers.get("session_before_compact")!(
+				{ reason: "threshold", branchEntries },
+				context,
+			) as { newContext: { handoff: string } }
+		).newContext.handoff;
+	const currentHandoff = automaticHandoff([
+		{ type: "message", id: "user", message: { role: "user", content: "keep working on the fix" } },
+	]);
+	assert.match(currentHandoff, /Automatic context rollover/);
+	assert.match(currentHandoff, /keep working on the fix/);
+	assert.equal(automaticHandoff([{ type: "context_window", id: "prior", handoff: "persisted task" }]), "persisted task");
+	assert.match(
+		automaticHandoff([
+			{ type: "context_window", id: "prior", handoff: "persisted task" },
+			{ type: "message", id: "image", message: { role: "user", content: [{ type: "image" }] } },
+		]),
 		/Automatic context rollover/,
 	);
 });
@@ -83,7 +95,23 @@ test("budget policy sends one reminder then requests automatic rollover", () => 
 		const reserve = SettingsManager.create(dir, getAgentDir()).getCompactionSettings().reserveTokens;
 		const rolloverAt = contextWindow - Math.min(reserve, Math.floor(contextWindow / 2));
 		const tokens = rolloverAt;
-		const branch: Record<string, unknown>[] = [];
+		const branch: Record<string, unknown>[] = [
+			{ type: "message", id: "old-user", message: { role: "user", content: "old completed task" } },
+			{ type: "context_window", id: "window-2" },
+			{
+				type: "message",
+				id: "current-user-1",
+				message: {
+					role: "user",
+					content: `Test production only. Do not contact other agents. ${"a".repeat(11_000)}`,
+				},
+			},
+			{
+				type: "message",
+				id: "current-user-2",
+				message: { role: "user", content: `${"b".repeat(11_000)} Write the three prompts.` },
+			},
+		];
 		const rollovers: Array<{ handoff?: string }> = [];
 		const context: TestContext = {
 			cwd: dir,
@@ -127,7 +155,13 @@ test("budget policy sends one reminder then requests automatic rollover", () => 
 		);
 		assert.equal(messages.length, 1);
 		assert.equal(rollovers.length, 1);
-		assert.match(rollovers[0].handoff ?? "", /Automatic context rollover/);
+		const handoff = rollovers[0].handoff ?? "";
+		assert.match(handoff, /Automatic context rollover/);
+		assert.match(handoff, /Test production only\. Do not contact other agents\./);
+		assert.match(handoff, /Write the three prompts\./);
+		assert.doesNotMatch(handoff, /old completed task/);
+		assert.match(handoff, /middle user messages omitted/);
+		assert.equal(handoff.length, 20_000);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- carry current-window user requests and constraints into bounded automatic handoffs
- reuse the persisted handoff across consecutive rollovers when no new user message exists
- let active work continue while completed work resets without an unsolicited response
- bump the GitHub-only release version to 0.2.2

Paired core fix: https://github.com/fitchmultz/pi/pull/3

## Verification

- `npm run check`
- `npm test` (4 passed)
- real extension + patched-core Harness: terminal `stop` leaves the next response unused; active `toolUse` continues in a fresh window
- pre-fix ablations reproduce missing handoffs, repeated-rollover loss, and stale image-only carryover