### PR TITLE
fix: keep notes with the main checkout from a linked git worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+- Resolves `notes` to the main checkout when Pi runs inside a linked git worktree, so every worktree of a repository shares one notebook and notes outlive the worktree.
+
 ## 0.3.0
 
 - Rebuilds automatic handoffs as bounded recovery records that retain direct user inputs, `ask_question` outcomes, visible coordination, and a clearly stale older checkpoint without inferring state from assistant prose.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Headroom follows Pi's `compaction.enabled` setting. Disabling automatic compacti
 - `notes({ op, ... })`: `list`, `read`, `write`, `append`, `search`
 - `history({ op, ... })`: `search`, `read`; results include native window IDs, and long reads return the next character offset
 
-Notes live in `.pi/notes/`. Add that directory to `.gitignore` when the project should not track them.
+Notes live in `.pi/notes/` of the main checkout; a linked git worktree shares that notebook instead of getting one that dies with the worktree. Add the directory to `.gitignore` when the project should not track it.
 
 ## Develop
 

--- a/index.ts
+++ b/index.ts
@@ -100,6 +100,16 @@ function textResult(text: string) {
 	return { content: [{ type: "text" as const, text }], details: undefined };
 }
 
+// A linked git worktree's `.git` is a file: "gitdir: <main>/.git/worktrees/<name>".
+// Notes then belong to the main checkout so every worktree shares them and they outlive the worktree.
+function notesRoot(cwd: string): string {
+	try {
+		const main = readFileSync(join(cwd, ".git"), "utf8").match(/^gitdir:\s*(.+)[\\/]\.git[\\/]worktrees[\\/][^\\/]+\s*$/m)?.[1];
+		if (main) return main;
+	} catch {}
+	return cwd;
+}
+
 function requireValue(value: string | undefined, name: string, op: string): string {
 	if (!value) throw new Error(`"${name}" is required for op "${op}".`);
 	return value;
@@ -436,7 +446,7 @@ export default function (pi: ExtensionAPI) {
 		name: "notes",
 		label: "Notes",
 		description:
-			"Persistent notes in .pi/notes/ that survive context resets. Ops: list, read, write (create/replace), append, search (case-insensitive substring over note lines).",
+			"Persistent notes in .pi/notes/ that survive context resets. Ops: list, read, write (create/replace), append, search (case-insensitive substring over note lines). Inside a linked git worktree the notes belong to the main checkout.",
 		promptSnippet: "save and recall durable state that survives context resets",
 		promptGuidelines: [
 			"Use notes for durable state too large for a new_context handoff",
@@ -452,7 +462,7 @@ export default function (pi: ExtensionAPI) {
 			query: Type.Optional(Type.String({ description: "Substring to find in notes (search)" })),
 		}),
 		async execute(_id, params, _signal, _onUpdate, ctx) {
-			const dir = join(ctx.cwd, ".pi", "notes");
+			const dir = join(notesRoot(ctx.cwd), ".pi", "notes");
 			const safeJoin = (path: string) => {
 				const relative = normalize(path.replace(/^[/\\]+/, ""));
 				if (relative === ".." || relative.startsWith(`..${sep}`) || isAbsolute(relative)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-headroom",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-headroom",
-			"version": "0.3.0",
+			"version": "0.3.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.84.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-headroom",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"type": "module",
 	"description": "Native no-summary context windows for a personal patched Pi, with sparse budget reminders, handoffs, notes, and history.",
 	"keywords": ["pi-package", "pi-extension", "context", "headroom"],

--- a/test/headroom.test.ts
+++ b/test/headroom.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -264,6 +264,32 @@ test("context filtering removes only reminders from an older window", () => {
 	const filtered = handlers.get("context")!({ messages: [marker, old, other, current] }, context) as { messages: unknown[] };
 	assert.deepEqual(filtered.messages, [marker, other, current]);
 	assert.equal(handlers.get("context")!({ messages: [marker, other, current] }, context), undefined);
+});
+
+test("notes from a linked git worktree belong to the main checkout", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "pi-headroom-notes-test-"));
+	try {
+		const main = join(dir, "main");
+		const worktree = join(dir, "wt");
+		const plain = join(dir, "plain");
+		mkdirSync(join(main, ".git", "worktrees", "wt"), { recursive: true });
+		mkdirSync(worktree);
+		writeFileSync(join(worktree, ".git"), `gitdir: ${join(main, ".git", "worktrees", "wt")}\n`);
+		mkdirSync(join(plain, ".git"), { recursive: true });
+		const { tools, context } = setup();
+		const notes = (cwd: string, params: Record<string, unknown>) =>
+			tools.get("notes")!.execute("id", params, new AbortController().signal, () => {}, { ...context, cwd });
+
+		await notes(worktree, { op: "write", path: "state.md", content: "from worktree" });
+		assert.equal(readFileSync(join(main, ".pi", "notes", "state.md"), "utf8"), "from worktree");
+		assert.equal(existsSync(join(worktree, ".pi")), false);
+		assert.equal(toolText(await notes(worktree, { op: "list" })), "state.md");
+
+		await notes(plain, { op: "write", path: "state.md", content: "from plain repo" });
+		assert.equal(readFileSync(join(plain, ".pi", "notes", "state.md"), "utf8"), "from plain repo");
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 });
 
 test("history reads current entries without opening every archived session", async () => {


### PR DESCRIPTION
`notes` resolved its folder as `join(ctx.cwd, ".pi", "notes")`. A Pi session started inside a linked git worktree therefore wrote to `<worktree>/.pi/notes/`: invisible from the main checkout and deleted when the worktree is removed after merge. (Absolute note paths do not escape this either: `safeJoin` strips the leading slash and nests the path.)

Fix: `notesRoot(cwd)` reads the worktree's `.git` pointer file (`gitdir: <main>/.git/worktrees/<name>`) and returns `<main>`; plain repositories, bare-repo pointers, and non-git directories keep using `cwd`. Every worktree of a repository now shares one notebook, and notes outlive the worktree.

- Test: new node:test case covering worktree → main, plain repo → cwd, and list from the worktree (red without the fix, green with it).
- Real `git worktree add` end-to-end check: a note written from the worktree lands in `main/.pi/notes/`, the worktree gets no `.pi/`, and the main checkout reads it back.
- `npm test` 10/10, `npm run check` clean. Version 0.3.1, changelog and README updated. No behavior change outside linked worktrees.
