### PR TITLE
Prioritize current recovery and original history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.2
 
 - Shows current-window inputs and unconsumed tool results before the older checkpoint in automatic recovery records.
 - Prioritizes original history matches over recovery notes, handoffs, and previous lookups without removing searchable entries or changing full reads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Shows current-window inputs and unconsumed tool results before the older checkpoint in automatic recovery records.
+- Prioritizes original history matches over recovery notes, handoffs, and previous lookups without removing searchable entries or changing full reads.
+- Reads each session file's modification time once when sorting, instead of repeatedly during comparisons.
+
 ## 0.4.1
 
 Compatibility update for Pi 0.85.0; runtime behavior is unchanged.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Keep exactly one copy loaded. `pi list` shows every package source; if an older 
 3. **`get_context_remaining`.** Reports the best available native estimate of tokens until Pi's automatic rollover line and until the model's hard limit. Pi's value is an estimate until the active model reports usage.
 4. **`new_context`.** Requests an atomic rollover after the complete tool batch succeeds. An optional handoff is persisted and becomes the first state of the fresh window. If a sibling tool in the same batch fails, Pi does not commit the boundary; the checkpoint reminder still applies.
 5. **Automatic rollover without summaries.** Posthorse claims Pi's automatic threshold and overflow trigger through `session_before_auto_compact`, before Pi resolves summarization credentials or prepares a summary. A single oversized first turn, an oversized tool result, or a missing summarization login all still roll over. Manual `/compact` is unchanged.
-6. **Bounded recovery record.** The automatic handoff keeps direct user inputs, `ask_question` outcomes, visible coordination messages, a clearly labeled older checkpoint, and the trailing tool batch that no model has consumed yet (call arguments, bounded result text, and the entry ids to recover the rest). Older assistant prose and consumed tool results are not treated as state. Newly submitted input stays separate and is saved after the boundary, not copied into the handoff.
+6. **Bounded recovery record.** The automatic handoff keeps direct user inputs, `ask_question` outcomes, visible coordination messages, and the trailing tool batch that no model has consumed yet (call arguments, bounded result text, and the entry ids to recover the rest). A clearly labeled, possibly stale older checkpoint comes last, after the current inputs and unseen results. Older assistant prose and consumed tool results are not treated as state. Newly submitted input stays separate and is saved after the boundary, not copied into the handoff.
 7. **`notes` and `history`.** Notes live with the repository root, shared across linked worktrees. History searches normalized transcript text and returns stored images for a requested entry.
 
 Automatic recovery is an emergency input record, not proof of progress. The fresh model is told to restore notes and todo state, inspect history when needed, and verify live state before taking stateful or external action.
@@ -73,7 +73,9 @@ Only one automatic compaction or rollover policy extension should be enabled at 
 
 Read pages, including returned images, shrink to the context that is actually left. Before usage is known, they reserve prompt/tool overhead and leave half the rest free. Unsafe pages are refused with the offset preserved; call `new_context` and retry.
 
-`history` with `all: true` scans every session file in the active Pi session directory, newest-modified sessions first and newest entries within each session; it is not a global newest-first ranking. Entries copied by a fork are reported once.
+`history search` puts matching original content before recovery material: handoffs, compaction and branch summaries, checkpoint reminders, and `notes`, `new_context`, and `history` calls/results. Ordinary prose or another tool call in the same assistant entry keeps its priority when that content matches. Every entry remains searchable; `history read` returns the complete normalized entry, including any recovery content omitted from a search excerpt.
+
+Within each group, current-branch matches are newest first. With `all: true`, Posthorse searches every session file in the active Pi session directory, newest-modified sessions first and newest entries within each session; this is not a global timestamp sort. The result limit applies after priority, so newer echoes cannot displace older original matches. Entries copied by a fork are reported once.
 
 Notes live in `.pi/notes/` at the repository root (the main checkout for a linked worktree, the current directory outside Git). Add the directory to `.gitignore` when the project should not track it.
 
@@ -99,4 +101,4 @@ npm run check
 PI_FORK=../pi scripts/integration.sh   # loads the real extension into the fork's test harness (fork built)
 ```
 
-`npm run check` type-checks `index.ts` and the unit tests; the integration test type-checks inside the fork. CI runs the unit tests on Node 22.19 and 24, `npm audit`, `npm pack --dry-run`, and the integration job against the pinned fork revision.
+`npm run check` type-checks `index.ts` and the unit tests; the integration test runs inside the fork's harness. CI runs the unit tests on Node 22.19 and 24, `npm audit`, `npm pack --dry-run`, and the integration job against the pinned fork revision.

--- a/index.ts
+++ b/index.ts
@@ -86,6 +86,7 @@ type EntryLike = {
 };
 
 type WindowedEntry = { entry: EntryLike; windowId: string; text: string; images: ImageLike[] };
+type HistoryHit = { id: string; text: string; priority: 0 | 1 };
 type RecoveryRecord = {
 	id: string;
 	timestamp: string;
@@ -215,6 +216,60 @@ function flattenEntry(entry: EntryLike): string | undefined {
 	return undefined;
 }
 
+function isRecoveryTool(name: unknown): boolean {
+	return name === "history" || name === "notes" || name === "new_context";
+}
+
+function isRecoveryCall(part: unknown): boolean {
+	const block = part as { type?: string; name?: string } | null;
+	return block?.type === "toolCall" && isRecoveryTool(block.name);
+}
+
+function historyHit(item: WindowedEntry, query: string, source = ""): HistoryHit | undefined {
+	const { entry } = item;
+	let text = item.text;
+	let matchIndex = text.toLowerCase().indexOf(query);
+	if (matchIndex === -1) return undefined;
+	let priority: 0 | 1 =
+		entry.type === "context_window" ||
+		entry.type === "compaction" ||
+		entry.type === "branch_summary" ||
+		(entry.type === "custom_message" && isReminderType(entry.customType)) ||
+		(entry.type === "message" && entry.message?.role === "toolResult" && isRecoveryTool(entry.message.toolName))
+			? 1
+			: 0;
+
+	if (
+		entry.type === "message" && entry.message?.role === "assistant" &&
+		Array.isArray(entry.message.content) && entry.message.content.some(isRecoveryCall)
+	) {
+		// A lookup beside a matching ordinary call or prose must not demote that original content.
+		const originals = [""];
+		for (const part of entry.message.content) {
+			if (isRecoveryCall(part)) {
+				originals.push("");
+			} else {
+				const partText = textOf({ content: [part] });
+				if (partText) originals[originals.length - 1] += `${originals.at(-1) ? "\n" : ""}${partText}`;
+			}
+		}
+		const images = imageSummary(item.images);
+		if (images) originals[originals.length - 1] += `${originals.at(-1) ? "\n" : ""}${images}`;
+		if (originals[0]) originals[0] = `[assistant] ${originals[0]}`;
+		const original = originals.find((part) => part.toLowerCase().includes(query));
+		priority = original ? 0 : 1;
+		if (original) {
+			text = original === originals[0] ? original : `[assistant] ${original}`;
+			matchIndex = text.toLowerCase().indexOf(query);
+		}
+	}
+	return {
+		id: entry.id!,
+		priority,
+		text: `${source ? `${source} ` : ""}${entry.timestamp ?? ""} [window ${item.windowId}] [${entry.id}] ${excerptAround(text, matchIndex, 100, 400)}`,
+	};
+}
+
 function toWindowedEntry(entry: EntryLike, windows: Map<string, string>): WindowedEntry | undefined {
 	const inheritedWindow = entry.parentId ? (windows.get(entry.parentId) ?? "initial") : "initial";
 	const windowId = entry.type === "context_window" && entry.id ? entry.id : inheritedWindow;
@@ -257,10 +312,14 @@ async function* sessionWindowEntries(file: string, signal?: AbortSignal): AsyncG
 
 function sessionFiles(dir: string): string[] {
 	if (!existsSync(dir)) return [];
-	return readdirSync(dir, { recursive: true, withFileTypes: true })
+	const files = readdirSync(dir, { recursive: true, withFileTypes: true })
 		.filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl") && !entry.name.includes(".intent."))
-		.map((entry) => join(entry.parentPath, entry.name))
-		.sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+		.map((entry) => join(entry.parentPath, entry.name));
+	if (files.length < 2) return files;
+	return files
+		.map((file) => ({ file, mtime: statSync(file).mtimeMs }))
+		.sort((a, b) => b.mtime - a.mtime)
+		.map(({ file }) => file);
 }
 
 function currentWindowId(entries: readonly EntryLike[]): string {
@@ -422,10 +481,10 @@ function buildAutoHandoff(entries: readonly EntryLike[], maxChars: number): stri
 		: undefined;
 	const minimumParts = [
 		preamble,
-		formatPriorCheckpoint(priorWindow, 0),
 		currentHeader,
 		...records.filter((record) => selected.has(record)).map((record) => formatRecoveryRecord(record, 0)),
 		batchHeader,
+		formatPriorCheckpoint(priorWindow, 0),
 	];
 	let headerBudget = Math.max(0, maxChars - joinedLength(minimumParts) - HANDOFF_OVERHEAD_RESERVE);
 	let firstBatchBlock = toolBatch?.blocks.length ?? 0;
@@ -461,7 +520,6 @@ function buildAutoHandoff(entries: readonly EntryLike[], maxChars: number): stri
 	);
 	const fixedParts = () => [
 		preamble,
-		prior,
 		currentHeader,
 		...records.filter((record) => selected.has(record)).map((record) => formatted.get(record)!),
 	];
@@ -471,7 +529,7 @@ function buildAutoHandoff(entries: readonly EntryLike[], maxChars: number): stri
 		const availableText = Math.max(
 			0,
 			maxChars -
-				joinedLength([...fixedParts(), bareBatch]) -
+				joinedLength([...fixedParts(), bareBatch, prior]) -
 				HANDOFF_OVERHEAD_RESERVE -
 				batchBlocks.length,
 		);
@@ -485,7 +543,7 @@ function buildAutoHandoff(entries: readonly EntryLike[], maxChars: number): stri
 			.join("\n\n");
 	}
 
-	let optionalBudget = Math.max(0, maxChars - joinedLength([...fixedParts(), batch]) - HANDOFF_OVERHEAD_RESERVE);
+	let optionalBudget = Math.max(0, maxChars - joinedLength([...fixedParts(), batch, prior]) - HANDOFF_OVERHEAD_RESERVE);
 	for (let i = records.length - 1; i >= 0; i--) {
 		const record = records[i];
 		if (selected.has(record)) continue;
@@ -499,7 +557,7 @@ function buildAutoHandoff(entries: readonly EntryLike[], maxChars: number): stri
 	const omission = omitted.length
 		? `Omitted ${omitted.length} current-window input(s) to stay within the handoff limit (${omitted.filter((record) => record.kind === "owner").length} owner, ${omitted.filter((record) => record.kind === "coordination").length} coordination; ${omitted[0].timestamp} through ${omitted.at(-1)!.timestamp}). Use history search/read to recover them.`
 		: undefined;
-	return [...fixedParts(), omission, batch].filter((part): part is string => Boolean(part)).join("\n\n");
+	return [...fixedParts(), omission, batch, prior].filter((part): part is string => Boolean(part)).join("\n\n");
 }
 
 /** Legacy reminders carry only windowId; they match on it alone until the model changes. */
@@ -880,7 +938,7 @@ export default function (pi: ExtensionAPI) {
 		name: "history",
 		label: "History",
 		description:
-			"Search or read normalized session entries, including earlier native context windows. Current branch is searched by default; all=true searches every project session file, newest-modified sessions first and newest entries within each session. Reads return stored images and page long text with the next offset.",
+			"Search or read normalized session entries, including earlier native context windows. Search prioritizes original content before recovery notes, handoffs, and history lookups; all remain searchable. Current branch by default; all=true searches every project session file. Within each group: newest-modified sessions first, newest entries per session. Reads return stored images and page long text with the next offset.",
 		promptSnippet: "recover earlier conversation that left the active context window",
 		promptGuidelines: ["Use history search first, then history read with the returned entry id"],
 		parameters: Type.Object({
@@ -897,39 +955,39 @@ export default function (pi: ExtensionAPI) {
 			if (params.op === "search") {
 				const query = requireValue(params.query, "query", params.op).toLowerCase();
 				const limit = params.limit ?? 10;
-				const hits: string[] = [];
+				const hits: string[][] = [[], []];
 				// Forks copy ancestor entries under the same ids into new session files; report each id once.
 				const seen = new Set<string>();
-				const addHit = (item: WindowedEntry, source = "") => {
-					const matchIndex = item.text.toLowerCase().indexOf(query);
-					if (matchIndex === -1 || seen.has(item.entry.id!)) return;
-					seen.add(item.entry.id!);
-					hits.push(
-						`${source ? `${source} ` : ""}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${item.entry.id}] ${excerptAround(item.text, matchIndex, 100, 400)}`,
-					);
+				const addHit = (hit: HistoryHit | undefined) => {
+					if (!hit || seen.has(hit.id) || hits[hit.priority].length >= limit) return;
+					seen.add(hit.id);
+					hits[hit.priority].push(hit.text);
 				};
 
 				if (params.all) {
-					files: for (const file of sessionFiles(manager.getSessionDir())) {
-						const recent: WindowedEntry[] = [];
+					for (const file of sessionFiles(manager.getSessionDir())) {
+						const recent: HistoryHit[][] = [[], []];
+						const source = relative(manager.getSessionDir(), file);
 						for await (const item of sessionWindowEntries(file, signal)) {
-							if (seen.has(item.entry.id!) || !item.text.toLowerCase().includes(query)) continue;
-							recent.push(item);
-							if (recent.length > limit - hits.length) recent.shift();
+							if (seen.has(item.entry.id!)) continue;
+							const hit = historyHit(item, query, source);
+							if (!hit) continue;
+							const group = recent[hit.priority];
+							group.push(hit);
+							if (group.length > limit - hits[hit.priority].length) group.shift();
 						}
-						for (const item of recent.reverse()) {
-							addHit(item, relative(manager.getSessionDir(), file));
-							if (hits.length >= limit) break files;
-						}
+						for (const group of recent) for (const hit of group.reverse()) addHit(hit);
+						if (hits[0].length >= limit) break;
 					}
 				} else {
 					const current = [...windowEntries(manager.getBranch() as EntryLike[])];
 					for (const item of current.reverse()) {
-						addHit(item);
-						if (hits.length >= limit) break;
+						addHit(historyHit(item, query));
+						if (hits[0].length >= limit) break;
 					}
 				}
-				return textResult(hits.length ? hits.join("\n") : `No history matches "${params.query}".`);
+				const results = hits.flat().slice(0, limit);
+				return textResult(results.length ? results.join("\n") : `No history matches "${params.query}".`);
 			}
 
 			const id = requireValue(params.id, "id", params.op);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-posthorse",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-posthorse",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.85.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-posthorse",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"type": "module",
 	"description": "Posthorse: fresh context, same journey. Native no-summary context windows for the fitchmultz/pi fork, with sparse budget reminders, handoffs, notes, and history.",
 	"keywords": ["pi-package", "pi-extension", "context", "posthorse", "rollover"],

--- a/test/integration/posthorse-in-pi.test.ts
+++ b/test/integration/posthorse-in-pi.test.ts
@@ -80,6 +80,11 @@ describe("Posthorse inside the Pi fork", () => {
 		const harness = await createHarness({ tools: [dump], extensionFactories: [posthorse] });
 		harnesses.push(harness);
 		forbidSummarizationAuth(harness);
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("new_context", { handoff: "FIRST read obsolete-checkpoint.md" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("ready"),
+		]);
+		await harness.session.prompt("checkpoint before current work");
 		let freshTexts: string[] = [];
 		harness.setResponses([
 			fauxAssistantMessage([{ type: "text", text: "OLD ASSISTANT PROSE" }, fauxToolCall("dump", {})], { stopReason: "toolUse" }),
@@ -92,7 +97,7 @@ describe("Posthorse inside the Pi fork", () => {
 
 		await harness.session.prompt("dump everything");
 
-		expect(contextWindows(harness)).toBe(1);
+		expect(contextWindows(harness)).toBe(2);
 		expect(branchTypes(harness).filter((type) => type === "compaction")).toEqual([]);
 		expect(freshTexts).toHaveLength(1);
 		const handoff = freshTexts[0];
@@ -101,12 +106,37 @@ describe("Posthorse inside the Pi fork", () => {
 		expect(handoff).toContain("Unconsumed tool batch");
 		expect(handoff).toMatch(/\[result entry [^\]]+\]\nDUMP HEAD r+\n… middle omitted …\nr+ DUMP TAIL/);
 		expect(handoff).not.toContain("OLD ASSISTANT PROSE");
+		expect(handoff.indexOf("dump everything")).toBeLessThan(handoff.indexOf("Unconsumed tool batch"));
+		expect(handoff.indexOf("DUMP TAIL")).toBeLessThan(handoff.indexOf("older checkpoint"));
+		expect(handoff).toContain("FIRST read obsolete-checkpoint.md");
 		expect(handoff.length).toBeLessThanOrEqual(20_000);
 
 		// The fresh window read the oversized result back through the append-only transcript.
 		const recovered = harness.session.messages.find((message) => message.role === "toolResult" && message.toolName === "history");
 		expect(getMessageText(recovered)).toMatch(/\[chars 0-\d+ of 600\d+\] \[toolResult\] DUMP HEAD/);
 		expect(getMessageText(recovered)).toMatch(/More remains; call history read with id ".+" and offset \d+\./);
+		expect(harness.getPendingResponseCount()).toBe(0);
+	});
+
+	it("finds the original request before its own persisted search call and keeps the call searchable", async () => {
+		const harness = await createHarness({ extensionFactories: [posthorse] });
+		harnesses.push(harness);
+		const results: string[] = [];
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("history", { op: "search", query: "needle", limit: 1 }), { stopReason: "toolUse" }),
+			(context) => {
+				results.push(getMessageText(context.messages.at(-1)));
+				return fauxAssistantMessage(fauxToolCall("history", { op: "search", query: '"limit":1', limit: 5 }), { stopReason: "toolUse" });
+			},
+			(context) => {
+				results.push(getMessageText(context.messages.at(-1)));
+				return fauxAssistantMessage("recovered");
+			},
+		]);
+		await harness.session.prompt("needle original request");
+		expect(results[0]).toContain("[user] needle original request");
+		expect(results[0]).not.toContain("[assistant] history");
+		expect(results[1]).toContain('[assistant] history {"op":"search","query":"needle","limit":1}');
 		expect(harness.getPendingResponseCount()).toBe(0);
 	});
 
@@ -159,7 +189,7 @@ describe("Posthorse inside the Pi fork", () => {
 		expect(handoff).not.toContain(PNG.slice(0, 20));
 		const recovered = harness.session.messages.find((message) => message.role === "toolResult" && message.toolName === "history");
 		expect(getMessageText(recovered)).toContain("[toolResult] SNAP CAPTION");
-		expect(recovered?.content).toContainEqual({ type: "image", data: PNG, mimeType: "image/png" });
+		expect(recovered).toMatchObject({ content: expect.arrayContaining([{ type: "image", data: PNG, mimeType: "image/png" }]) });
 	});
 
 	it("rolls over a single oversized first owner turn on overflow and retries once", async () => {

--- a/test/posthorse.test.ts
+++ b/test/posthorse.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -121,6 +121,7 @@ test("new_context returns an atomic handoff and automatic rollover builds a reco
 	assert.match(prior, /older checkpoint; possibly stale/);
 	assert.match(prior, /persisted task/);
 	assert.match(prior, /No selected current-window/);
+	assert.ok(prior.indexOf("No selected current-window") < prior.indexOf("older checkpoint"));
 
 	const nonRecursive = automaticHandoff(handlers, context, [
 		{
@@ -184,6 +185,7 @@ test("automatic recovery keeps owner anchors and visible coordination without st
 	assert.match(handoff, /Omitted \d+ current-window input/);
 	assert.ok(handoff.indexOf("entry owner-start") < handoff.indexOf("entry owner-answer"));
 	assert.ok(handoff.indexOf("entry owner-answer") < handoff.indexOf("entry latest-correction"));
+	assert.ok(handoff.indexOf("entry latest-correction") < handoff.indexOf("older checkpoint"));
 	assert.doesNotMatch(handoff, /old completed task|hidden state|stale reminder|assistant-derived state/);
 });
 
@@ -440,6 +442,94 @@ test("history searches normalized text and reports native window ids", async () 
 	assert.match(toolText(secondPage), /needle tail/);
 });
 
+test("history ranks matching original content before recovery and lookup echoes without hiding either", async () => {
+	const { tools, context: base } = setup();
+	const image = { type: "image", data: "UE5HREFUQQ==", mimeType: "image/png" };
+	const branch = [
+		{ type: "message", id: "owner", message: { role: "user", content: "needle original request" } },
+		{ type: "message", id: "assistant", message: { role: "assistant", content: "needle original response" } },
+		{ type: "message", id: "result", message: { role: "toolResult", toolName: "read", content: "needle original output" } },
+		{ type: "context_window", id: "window", handoff: "needle checkpoint" },
+		{ type: "compaction", id: "summary", summary: "needle summary" },
+		{ type: "branch_summary", id: "branch-summary", summary: "needle branch summary" },
+		{ type: "custom_message", id: "reminder", customType: "posthorse-reminder", content: "needle reminder" },
+		{ type: "custom_message", id: "legacy", customType: "headroom-reminder", content: "needle legacy reminder" },
+		{ type: "message", id: "notes", message: { role: "toolResult", toolName: "notes", content: "needle saved note" } },
+		{ type: "message", id: "lookup", message: { role: "toolResult", toolName: "history", content: [{ type: "text", text: "needle recovered output" }, image] } },
+		{ type: "message", id: "rollover", message: { role: "assistant", content: [{ type: "toolCall", name: "new_context", arguments: { handoff: "needle" } }] } },
+		{ type: "message", id: "mixed-call", message: { role: "assistant", content: [
+			{ type: "toolCall", name: "notes", arguments: { op: "write", content: `needle ECHO ${"x".repeat(500)}` } },
+			{ type: "toolCall", name: "bash", arguments: { command: "needle MATCHING SIBLING" } },
+		] } },
+		{ type: "message", id: "mixed-prose", message: { role: "assistant", content: [
+			{ type: "text", text: "needle MATCHING PROSE" },
+			{ type: "text", text: "second line" },
+			{ type: "toolCall", name: "history", arguments: { op: "search", query: `needle ECHO ${"x".repeat(500)}` } },
+		] } },
+		{ type: "message", id: "mixed-echo", message: { role: "assistant", content: [
+			{ type: "toolCall", name: "history", arguments: { op: "search", query: "needle lookup-only" } },
+			{ type: "text", text: "ordinary prose does not match" },
+		] } },
+		{ type: "message", id: "current-search", message: { role: "assistant", content: [{ type: "toolCall", name: "history", arguments: { op: "search", query: "[assistant] needle MATCHING PROSE" } }] } },
+	].map((entry, index, entries) => ({ ...entry, timestamp: `${index}`, parentId: entries[index - 1]?.id ?? null }));
+	const context = { ...base, sessionManager: { getBranch: () => branch, getSessionDir: () => join(tmpdir(), "missing") } };
+	const search = async (query: string, limit = 50) => toolText(await run(tools, "history", { op: "search", query, limit }, context));
+	const ids = (text: string) => [...text.matchAll(/\[window [^\]]+\] \[([^\]]+)\]/g)].map((match) => match[1]);
+	const all = await search("NEEDLE");
+	assert.deepEqual(ids(all), [
+		"mixed-prose", "mixed-call", "result", "assistant", "owner",
+		"current-search", "mixed-echo", "rollover", "lookup", "notes", "legacy", "reminder", "branch-summary", "summary", "window",
+	]);
+	const originals = await search("needle", 5);
+	assert.deepEqual(ids(originals), ids(all).slice(0, 5));
+	assert.match(originals, /MATCHING PROSE/);
+	assert.match(originals, /MATCHING SIBLING/);
+	assert.doesNotMatch(originals, /ECHO/);
+	assert.deepEqual(ids(await search("needle", 1)), ["mixed-prose"]);
+	assert.deepEqual(ids(await search("needle MATCHING PROSE\nsecond line", 1)), ["mixed-prose"]);
+	assert.deepEqual(ids(await search("[assistant] needle MATCHING PROSE", 1)), ["mixed-prose"]);
+	assert.deepEqual(ids(await search("lookup-only")), ["mixed-echo"]);
+	assert.match(all, /\[window window\] \[mixed-call\]/);
+	const read = await run(tools, "history", { op: "read", id: "mixed-call" }, context);
+	assert.match(toolText(read), /needle ECHO/);
+	assert.match(toolText(read), /MATCHING SIBLING/);
+	const recovered = await run(tools, "history", { op: "read", id: "lookup" }, context);
+	assert.match(toolText(recovered), /needle recovered output/);
+	assert.deepEqual(recovered.content.slice(1), [image]);
+});
+
+test("all-session ranking keeps older originals ahead of newer echoes before applying the result limit", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "pi-posthorse-ranking-test-"));
+	try {
+		const old = { type: "message", id: "old", message: { role: "user", content: "needle oldest original" } };
+		const newer = { type: "message", id: "newer", message: { role: "toolResult", toolName: "bash", content: "needle newer original" } };
+		const echoes = Array.from({ length: 6 }, (_, index) => ({
+			type: "message", id: `echo-${index}`, message: { role: "toolResult", toolName: "history", content: `needle echo-only ${index}` },
+		}));
+		for (const [index, entries] of [[old], [newer, ...echoes], [echoes[5]]].entries()) {
+			const file = join(dir, `${index}.jsonl`);
+			writeFileSync(file, entries.map((entry) => JSON.stringify(entry)).join("\n"));
+			utimesSync(file, new Date((index + 1) * 1000), new Date((index + 1) * 1000));
+		}
+		const { tools, context: base } = setup();
+		const context = { ...base, sessionManager: { getBranch: () => [], getSessionDir: () => dir } };
+		const search = async (query: string, limit: number) => toolText(await run(tools, "history", { op: "search", query, all: true, limit }, context));
+		const ids = (text: string) => [...text.matchAll(/\[window initial\] \[([^\]]+)\]/g)].map((match) => match[1]);
+		assert.deepEqual(ids(await search("needle", 1)), ["newer"]);
+		assert.deepEqual(ids(await search("needle", 2)), ["newer", "old"]);
+		assert.deepEqual(ids(await search("needle", 4)), ["newer", "old", "echo-5", "echo-4"]);
+		const all = await search("needle", 50);
+		assert.deepEqual(ids(all), ["newer", "old", ...echoes.map((entry) => entry.id).reverse()]);
+		assert.match(all, /2\.jsonl[^\n]+\[echo-5\]/, "fork copies use the newest file");
+		assert.deepEqual(ids(await search("echo-only", 2)), ["echo-5", "echo-4"]);
+		const controller = new AbortController();
+		controller.abort();
+		await assert.rejects(tools.get("history")!.execute("id", { op: "search", query: "needle", all: true }, controller.signal, () => {}, context), { name: "AbortError" });
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
 test("a persisted legacy headroom-reminder still deduplicates, and a model switch invalidates it", () => {
 	const { handlers, messages, context: base } = setup();
 	const branch: Record<string, unknown>[] = [
@@ -480,6 +570,7 @@ test("automatic handoff carries only the trailing unconsumed tool batch, with en
 	const { handlers, context } = setup();
 	const image = { type: "image", data: "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=", mimeType: "image/png" };
 	const batch: Record<string, unknown>[] = [
+		{ type: "context_window", id: "older-window", handoff: "FIRST read obsolete-checkpoint.md" },
 		{ type: "message", id: "owner", timestamp: "1", message: { role: "user", content: "run the checks" } },
 		{
 			type: "message",
@@ -510,6 +601,9 @@ test("automatic handoff carries only the trailing unconsumed tool batch, with en
 	assert.match(handoff, /\[result entry result-3\]\n\[1 image: image\/png\] — recover with history read id result-3/);
 	assert.doesNotMatch(handoff, /ASSISTANT PROSE|QUJDREVG/);
 	assert.ok(handoff.indexOf("entry result-1") < handoff.indexOf("entry result-2"), "results keep their order");
+	assert.ok(handoff.indexOf("entry owner") < handoff.indexOf("Unconsumed tool batch"));
+	assert.ok(handoff.indexOf("entry result-3") < handoff.indexOf("older checkpoint"));
+	assert.match(handoff, /FIRST read obsolete-checkpoint\.md/);
 
 	const errored = automaticHandoff(handlers, context, [
 		...batch,
@@ -836,6 +930,29 @@ test("all-session search reports a fork-copied entry once, from the newest-modif
 			["fork.jsonl[fork-new] [", "fork.jsonl[shared] ["],
 		);
 		assert.equal(text.match(/\[shared\]/g)?.length, 1);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("session search and archived reads preserve modification-time ordering including ties", async () => {
+	const dir = mkdtempSync(join(tmpdir(), "pi-posthorse-mtime-test-"));
+	try {
+		for (const [name, mtime] of [["z", 1000], ["m", 2000], ["a", 2000]] as const) {
+			const file = join(dir, `${name}.jsonl`);
+			writeFileSync(file, [
+				{ type: "message", id: "shared", message: { role: "user", content: "shared ancestor" } },
+				{ type: "message", id: name, parentId: "shared", message: { role: "user", content: "mtime needle" } },
+			].map((entry) => JSON.stringify(entry)).join("\n"));
+			utimesSync(file, new Date(mtime), new Date(mtime));
+		}
+		const expected = readdirSync(dir).sort((a, b) => statSync(join(dir, b)).mtimeMs - statSync(join(dir, a)).mtimeMs);
+		const { tools, context: base } = setup();
+		const context = { ...base, sessionManager: { getBranch: () => [], getSessionDir: () => dir } };
+		const search = toolText(await run(tools, "history", { op: "search", query: "mtime needle", all: true }, context));
+		assert.deepEqual(search.split("\n").map((line) => line.split(" ")[0]), expected);
+		const read = toolText(await run(tools, "history", { op: "read", id: "shared" }, context));
+		assert.equal(read.split(" ")[0], expected[0]);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary

- Put current-window inputs and unconsumed tool results before the possibly stale older checkpoint in automatic recovery records, preserving the existing handoff budget.
- Rank original history matches before recovery notes, handoffs, and previous lookups. Keep every entry searchable and full reads unchanged; matching ordinary prose or sibling tool calls in a mixed entry keep their priority.
- Read each session file's modification time once before sorting rather than during every comparison. Preserve ordering, including ties, without adding scan limits or an index.

## Validation

- `npm test`: 25 tests passed.
- `npm run check`: passed.
- Native Pi harness at `fitchmultz/pi@63fe909af584d46af3c3221dcf27ed14b97a4ec3`: 9 tests passed; separate native integration typecheck passed.
- Regression checks against the pre-fix implementation reproduce the recovery ordering and search self-echo failures: 5 unit failures and 2 native harness failures, then pass with the fix.
- Synthetic modification-time sorting checks preserve the exact result order, including ties and zero/one-file cases. For 1,000 mixed-mtime files, stat calls drop from 17,230 to 1,000. This measures sorting only, not whole-history search latency.
- `npm pack --dry-run`: only the intended package files.

Includes v0.4.2 version and changelog metadata for the GitHub release. No npm publication, installed-package update, or running-session change.
