### PR TITLE
fix: avoid unnecessary session scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.4
+
+- Skips full-branch lookups outside the checkpoint reminder band and when model input contains no checkpoint reminders.
+
 ## 0.4.3
 
 Documentation correction; runtime behavior is unchanged.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pi owns the persisted boundary. Posthorse owns the policy: stable window guidanc
 ## Requirements
 
 - Node `>=22.19.0`.
-- The `fitchmultz/pi` fork. The current tested revision is `f9b06177e565f70cd243a785d088d1c491830dbd` (Pi `0.85.0`). Posthorse needs the fork's native `context_window` entries, its `session_before_auto_compact` hook, and `ctx.getCompactionSettings()`.
+- The `fitchmultz/pi` fork. The CI baseline is `f9b06177e565f70cd243a785d088d1c491830dbd` (Pi `0.85.0`). Posthorse needs the fork's native `context_window` entries, its `session_before_auto_compact` hook, and `ctx.getCompactionSettings()`.
 - Official, unpatched Pi is unsupported. Posthorse reports a clear extension error at session start and cannot operate; Pi itself keeps running.
 
 ## Install
@@ -53,6 +53,8 @@ Keep exactly one copy loaded. `pi list` shows every package source; if an older 
 5. **Automatic rollover without summaries.** With a supported context budget and room for a recovery record, Posthorse claims Pi's automatic threshold and overflow trigger through `session_before_auto_compact`, before Pi resolves summarization credentials or prepares a summary. Oversized first turns and tool results can then roll over even without summarization credentials. Otherwise Pi's own compaction remains in control. Manual `/compact` is unchanged.
 6. **Bounded recovery record.** The automatic handoff keeps direct user inputs, `ask_question` outcomes, visible coordination messages, and the trailing tool batch that no model has consumed yet (call arguments, bounded result text, and the entry ids to recover the rest). A clearly labeled, possibly stale older checkpoint comes last, after the current inputs and unseen results. Older assistant prose and consumed tool results are not treated as state. Newly submitted input stays separate and is saved after the boundary, not copied into the handoff.
 7. **`notes` and `history`.** Notes live with the repository root, shared across linked worktrees. History searches normalized transcript text and returns stored images for a requested entry.
+
+At turn end, Posthorse checks whether usage is in the reminder band before explicitly looking up the full branch. Context filtering skips its branch lookup when model input contains neither `posthorse-reminder` nor legacy `headroom-reminder` messages. History searches, reads, and recovery remain available with no new limits.
 
 Automatic recovery is an emergency input record, not proof of progress. The fresh model is told to restore notes and todo state, inspect history when needed, and verify live state before taking stateful or external action.
 
@@ -103,4 +105,4 @@ npm run check
 PI_FORK=../pi scripts/integration.sh   # loads the real extension into the fork's test harness (fork built)
 ```
 
-`npm run check` type-checks `index.ts` and the unit tests; the integration test runs inside the fork's harness. CI runs the unit tests on Node 22.19 and 24, `npm audit`, `npm pack --dry-run`, and the integration job against the pinned fork revision.
+`npm run check` type-checks `index.ts` and the unit tests; the integration test runs inside the fork's harness. Unit tests cover reminder boundaries, skipped branch lookups, and legacy reminders; native integration tests cover rollover and history recovery. CI runs the unit tests on Node 22.19 and 24, `npm audit`, `npm pack --dry-run`, and the integration job against the pinned fork revision.

--- a/index.ts
+++ b/index.ts
@@ -719,6 +719,10 @@ export default function (pi: ExtensionAPI) {
 		if (!usage || usage.tokens == null || usage.contextWindow <= 0) return;
 		const budget = budgetFor(native, usage.contextWindow);
 		if (!budget || !budget.enabled || !budget.supported) return;
+		if (usage.tokens >= budget.rolloverAt) return;
+		const reminderBuffer = Math.min(REMINDER_BUFFER_TOKENS, Math.floor(budget.usable * 0.1));
+		const remindAt = budget.rolloverAt - reminderBuffer;
+		if (usage.tokens < remindAt) return;
 
 		const branch = ctx.sessionManager.getBranch() as EntryLike[];
 		const fingerprint: ReminderFingerprint = {
@@ -726,10 +730,7 @@ export default function (pi: ExtensionAPI) {
 			contextWindow: budget.contextWindow,
 			reserveTokens: budget.reserveTokens,
 		};
-		if (usage.tokens >= budget.rolloverAt) return;
-		const reminderBuffer = Math.min(REMINDER_BUFFER_TOKENS, Math.floor(budget.usable * 0.1));
-		const remindAt = budget.rolloverAt - reminderBuffer;
-		if (usage.tokens < remindAt || hasReminder(branch, fingerprint)) return;
+		if (hasReminder(branch, fingerprint)) return;
 		pi.sendMessage(
 			{
 				customType: REMINDER_TYPE,
@@ -749,6 +750,7 @@ export default function (pi: ExtensionAPI) {
 		const windowId = marker?.role === "custom" ? (marker.details as { windowId?: unknown } | undefined)?.windowId : "initial";
 		if (typeof windowId !== "string") return;
 		const native = nativeContext(ctx);
+		if (!event.messages.some((message) => message.role === "custom" && isReminderType(message.customType))) return;
 		const budget = budgetFor(native);
 		const branch = ctx.sessionManager.getBranch() as EntryLike[];
 		const fingerprint: ReminderFingerprint = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-posthorse",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-posthorse",
-			"version": "0.4.3",
+			"version": "0.4.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.85.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-posthorse",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"type": "module",
 	"description": "Posthorse: fresh context, same journey. Native no-summary context windows for the fitchmultz/pi fork, with sparse budget reminders, handoffs, notes, and history.",
 	"keywords": ["pi-package", "pi-extension", "context", "posthorse", "rollover"],

--- a/test/posthorse.test.ts
+++ b/test/posthorse.test.ts
@@ -215,10 +215,11 @@ test("budget policy sends one best-effort reminder below the line and lets Pi ow
 		let tokens = remindAt - 1;
 		const branch: Record<string, unknown>[] = [{ type: "context_window", id: "window-2" }];
 		const rollovers: Array<{ handoff?: string }> = [];
+		let branchReads = 0;
 		const context: TestContext = {
 			cwd: dir,
 			model: { contextWindow },
-			sessionManager: { getBranch: () => branch, getSessionDir: () => dir },
+			sessionManager: { getBranch: () => { branchReads++; return branch; }, getSessionDir: () => dir },
 			getContextUsage: () => ({ tokens, contextWindow, percent: (tokens / contextWindow) * 100 }),
 			getCompactionSettings: () => ({ enabled: true, reserveTokens: reserve }),
 			getSystemPrompt: () => "You are a test assistant.",
@@ -228,6 +229,7 @@ test("budget policy sends one best-effort reminder below the line and lets Pi ow
 		handlers.get("session_start")!({}, context);
 		turnEnd(handlers, context);
 		assert.equal(messages.length, 0, "no reminder below the band");
+		assert.equal(branchReads, 0, "below-band turns must not fetch history");
 		tokens = remindAt;
 		turnEnd(handlers, context, [{ toolName: "new_context" }]);
 		assert.equal(messages.length, 0);
@@ -235,12 +237,14 @@ test("budget policy sends one best-effort reminder below the line and lets Pi ow
 		assert.equal(messages.length, 0);
 		handlers.get("turn_end")!({ message: { role: "assistant", stopReason: "aborted" }, toolResults: [] }, context);
 		assert.equal(messages.length, 0);
+		assert.equal(branchReads, 0, "successful rollover batches, errors, and aborts need no history");
 
 		turnEnd(handlers, context);
 		assert.equal(messages.length, 1);
 		assert.match(messages[0].content, /Checkpoint now/);
 		assert.match(messages[0].content, /call new_context now/);
 		assert.deepEqual(messages[0].details, { windowId: "window-2", contextWindow, reserveTokens: reserve });
+		assert.equal(branchReads, 1, "the first token in the reminder band checks the current window");
 		branch.push({ type: "custom_message", customType: "posthorse-reminder", details: messages[0].details });
 
 		tokens = threshold;
@@ -250,14 +254,17 @@ test("budget policy sends one best-effort reminder below the line and lets Pi ow
 		messages.length = 0;
 		turnEnd(handlers, context);
 		assert.equal(messages.length, 1, "Posthorse still offers a checkpoint at equality");
+		assert.equal(branchReads, 3, "in-band turns recheck persisted reminders, including threshold equality");
 
 		messages.length = 0;
 		tokens = rolloverAt;
 		turnEnd(handlers, context);
 		assert.equal(messages.length, 0, "Pi owns the first token that actually triggers rollover");
+		assert.equal(branchReads, 3, "rollover equality must not fetch history");
 		tokens += 1_000;
 		turnEnd(handlers, context);
 		assert.equal(messages.length, 0, "Posthorse also stays out of Pi's over-threshold path");
+		assert.equal(branchReads, 3, "over-threshold turns must not fetch history");
 		assert.equal(rollovers.length, 0);
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
@@ -290,6 +297,42 @@ test("disabled Pi compaction disables automatic Posthorse behavior but not new_c
 	assert.match(remaining, /1,000 tokens until the hard context limit/);
 	const result = await run(tools, "new_context", {}, context);
 	assert.deepEqual(result.newContext, { handoff: undefined });
+});
+
+test("reminder-free context skips history without hiding native compatibility errors", () => {
+	const { handlers, context } = setup();
+	const marker = { role: "custom", customType: "context-window", content: "new", details: { windowId: "new" } };
+	const user = { role: "user", content: "posthorse-reminder and headroom-reminder are just text here" };
+	const other = { role: "custom", customType: "intercom_message", content: "keep" };
+	let branchReads = 0;
+	context.sessionManager.getBranch = () => {
+		branchReads++;
+		return [{ type: "custom_message", customType: "headroom-reminder", details: { windowId: "old" } }];
+	};
+	for (const method of ["newContext", "getCompactionSettings", "getSystemPrompt"]) {
+		const incompatible = { ...context };
+		Reflect.deleteProperty(incompatible, method);
+		assert.throws(
+			() => handlers.get("context")!({ messages: [marker, user, other] }, incompatible),
+			/Posthorse requires the fitchmultz\/pi fork/,
+		);
+	}
+	for (const messages of [[], [user, other], [marker, user, other]]) {
+		const original = structuredClone(messages);
+		assert.equal(handlers.get("context")!({ messages }, context), undefined);
+		assert.deepEqual(messages, original, "unrelated messages remain unchanged");
+	}
+	assert.equal(branchReads, 0, "no history is needed even if old reminders remain in the transcript");
+	for (const customType of ["posthorse-reminder", "headroom-reminder"]) {
+		const current = { role: "custom", customType, content: "current", details: { windowId: "new" } };
+		const stale = { ...current, content: "stale", details: { windowId: "old" } };
+		assert.deepEqual(
+			handlers.get("context")!({ messages: [marker, user, other, stale, current] }, context),
+			{ messages: [marker, user, other, current] },
+			`${customType} alone must still trigger stale filtering`,
+		);
+	}
+	assert.equal(branchReads, 2, "both reminder types still consult history when present");
 });
 
 test("context filtering removes reminders from an older window or a different budget, legacy ids included", () => {


### PR DESCRIPTION
## Summary
- Skip full-branch lookups outside the existing checkpoint reminder band and when context contains neither current nor legacy reminder messages.
- Preserve reminder boundaries, deduplication, stale filtering, native compatibility checks, rollover, and existing history/notes/recovery behavior; no new limits.
- Update the README and changelog for version **0.4.4**; no dependency changes.

## Validation
- Verified clean-head receipts for `0fc6e5e4a9d2d8a8f6a1511680330fa13b200914`: **26 tests passed**, typecheck passed, full audit found **0 vulnerabilities**, and the pack dry run contained only LICENSE, README.md, index.ts, and package.json.
- Regression assertions fail against the pre-fix source on unnecessary branch reads and pass with this change.
- [Exact-head PR CI passed](https://github.com/fitchmultz/pi-posthorse/actions/runs/33946974196): **test (22.19)**, **test (24)**, and **integration**. Each unit job passed all 26 tests, typecheck, audit, and pack dry run; integration passed all 9 tests against pinned Pi `f9b06177e565f70cd243a785d088d1c491830dbd`.
- The final paired check with the companion Pi change is tracked separately; pinned-Pi CI does not verify that change.

Companion: https://github.com/fitchmultz/pi/pull/8

This reduces local reminder-related work. It does not establish the cause of provider pauses or mean either installed fix is active.
