### PR TITLE
Add native expandable Posthorse tool cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Adds native expandable cards for context budgets, notes, history, and context requests, with compact previews, result counts, and visible page ranges and continuation offsets.
+- Keeps committed context-window handoffs and checkpoint reminders compact until expanded. Model-visible tool text, prompts, context policy, and stored note/history content are unchanged.
+- Corrects update instructions to require restarting Pi to load new extension code.
+
 ## 0.4.4
 
 - Skips full-branch lookups outside the checkpoint reminder band and when model input contains no checkpoint reminders.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pi -e git:github.com/fitchmultz/pi-posthorse              # try it for one run w
 
 Update with `pi update npm:pi-posthorse` or `pi update --extensions`; move a pinned Git install with `pi install git:github.com/fitchmultz/pi-posthorse@<new tag>`. Uninstall with `pi remove npm:pi-posthorse` (or the Git source you installed). Removing the package leaves `.pi/notes` and Pi's session history in place.
 
-After installing or updating Posthorse, run `/reload` in existing Pi sessions or restart them to load the new version.
+Restart Pi after installing or updating Posthorse to load the new extension code.
 
 Keep exactly one copy loaded. `pi list` shows every package source; if an older entry such as `git:github.com/fitchmultz/pi-headroom.git` or a local checkout is still listed, `pi remove` it before installing the npm package, otherwise two copies register the same tools and compete for the same rollover hook.
 
@@ -75,6 +75,10 @@ Only one automatic compaction or rollover policy extension should be enabled at 
 - `notes({ op, ... })`: `list`, `read` (paged; `offset` continues), `write` (empty content clears), `append` (one atomic newline-terminated record), `search` (excerpts centered on the match)
 - `history({ op, ... })`: `search`, `read`; results carry native window ids, reads return stored images with the first page and the next character offset when text remains
 
+In the TUI, tools use Pi's native expandable cards. Collapsed cards show the operation and target, a short content preview, and counts or page ranges with the next offset when more remains. Expand with Pi's tool-output shortcut (`Ctrl+O` by default), or click the card's header or body in fullscreen mode. Expanded cards show the complete returned page and its metadata, not content the tool has not fetched yet. Writes and context requests also show the submitted content or handoff.
+
+Committed context-window messages and checkpoint reminders are compact, expandable cards too. The `new_context` tool card describes a request; only the committed context-window message says a fresh window has started.
+
 Read pages, including returned images, shrink to the context that is actually left. Before usage is known, they reserve prompt/tool overhead and leave half the rest free. Unsafe pages are refused with the offset preserved; call `new_context` and retry.
 
 `history search` puts matching original content before recovery material: handoffs, compaction and branch summaries, checkpoint reminders, and `notes`, `new_context`, and `history` calls/results. Ordinary prose or another tool call in the same assistant entry keeps its priority when that content matches. Every entry remains searchable; `history read` returns the complete normalized entry, including any recovery content omitted from a search excerpt.
@@ -105,4 +109,4 @@ npm run check
 PI_FORK=../pi scripts/integration.sh   # loads the real extension into the fork's test harness (fork built)
 ```
 
-`npm run check` type-checks `index.ts` and the unit tests; the integration test runs inside the fork's harness. Unit tests cover reminder boundaries, skipped branch lookups, and legacy reminders; native integration tests cover rollover and history recovery. CI runs the unit tests on Node 22.19 and 24, `npm audit`, `npm pack --dry-run`, and the integration job against the pinned fork revision.
+`npm run check` type-checks the extension, renderers, and tests. Tests cover reminder policy, notes/history behavior, and real native card components, including width, expansion, and legacy results. The pinned Pi 0.85.0 SDK's unbundled entry imports an undeclared server package, so test-only resolution loads its shipped native bundle. Integration tests run inside the fork's harness and cover rollover and history recovery; use a disposable built fork checkout because the script briefly copies the test into its test directory. CI runs the unit tests on Node 22.19 and 24, `npm audit`, `npm pack --dry-run`, and the integration job against the pinned fork revision.

--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,7 @@ import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from "no
 import { createInterface } from "node:readline";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import { registerPosthorseMessages, toolCards, type PosthorseDisplay } from "./ui.ts";
 
 const REMINDER_BUFFER_TOKENS = 32_000;
 /** Absolute ceiling for handoffs and read pages; pages shrink to the live remaining budget. */
@@ -86,7 +87,7 @@ type EntryLike = {
 };
 
 type WindowedEntry = { entry: EntryLike; windowId: string; text: string; images: ImageLike[] };
-type HistoryHit = { id: string; text: string; priority: 0 | 1 };
+type HistoryHit = { id: string; text: string; headerLength: number; priority: 0 | 1 };
 type RecoveryRecord = {
 	id: string;
 	timestamp: string;
@@ -159,8 +160,8 @@ function textOf(message: MessageLike): string {
 		.join("\n");
 }
 
-function textResult(text: string, images: ImageLike[] = []) {
-	return { content: [{ type: "text" as const, text }, ...images], details: undefined };
+function textResult(text: string, images: ImageLike[] = [], display?: PosthorseDisplay) {
+	return { content: [{ type: "text" as const, text }, ...images], details: display };
 }
 
 /**
@@ -263,10 +264,12 @@ function historyHit(item: WindowedEntry, query: string, source = ""): HistoryHit
 			matchIndex = text.toLowerCase().indexOf(query);
 		}
 	}
+	const header = `${source ? `${source} ` : ""}${entry.timestamp ?? ""} [window ${item.windowId}] [${entry.id}] `;
 	return {
 		id: entry.id!,
 		priority,
-		text: `${source ? `${source} ` : ""}${entry.timestamp ?? ""} [window ${item.windowId}] [${entry.id}] ${excerptAround(text, matchIndex, 100, 400)}`,
+		text: `${header}${excerptAround(text, matchIndex, 100, 400)}`,
+		headerLength: header.length,
 	};
 }
 
@@ -678,6 +681,7 @@ Automatic handoffs are emergency recovery records, not proof of current state. R
 }
 
 export default function (pi: ExtensionAPI) {
+	registerPosthorseMessages(pi);
 	const activeToolTokens = () => {
 		const active = new Set(pi.getActiveTools());
 		return pi
@@ -781,6 +785,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "new_context",
 		label: "New Context",
+		...toolCards("new_context"),
 		description:
 			"Start a genuinely fresh context window after this tool batch. Earlier conversation leaves active context without a generated summary but remains recoverable through history. Pass concise continuation state in handoff, or save richer state with notes first.",
 		promptSnippet: "start a fresh context window with an optional atomic handoff",
@@ -807,6 +812,8 @@ export default function (pi: ExtensionAPI) {
 			return {
 				...textResult(
 					"Requested a fresh Pi context after this complete tool batch succeeds. Earlier conversation stays in session history.",
+					[],
+					{ kind: "new-context" },
 				),
 				newContext: { handoff: trimmed },
 			};
@@ -816,6 +823,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "get_context_remaining",
 		label: "Context Remaining",
+		...toolCards("get_context_remaining"),
 		description:
 			"Best available native estimate of the context budget: tokens until Pi's automatic rollover line and until the model's hard limit.",
 		promptSnippet: "check the remaining context budget only when needed",
@@ -823,14 +831,20 @@ export default function (pi: ExtensionAPI) {
 		async execute(_id, _params, _signal, _onUpdate, ctx) {
 			const native = nativeContext(ctx);
 			const usage = native.getContextUsage();
-			if (!usage || usage.tokens == null) return textResult("Context usage is not known until the next model response.");
+			if (!usage || usage.tokens == null) return textResult("Context usage is not known until the next model response.", [], { kind: "context" });
 			const n = (value: number) => value.toLocaleString("en-US");
 			const budget = budgetFor(native, usage.contextWindow);
+			const display: PosthorseDisplay = {
+				kind: "context", usage,
+				rollover: !budget?.enabled ? "disabled" : budget.supported ? "enabled" : "unsupported",
+				rolloverAt: budget?.rolloverAt,
+			};
 			const hard = `≈${n(Math.max(0, usage.contextWindow - usage.tokens))} tokens until the hard context limit (${n(usage.tokens)}/${n(usage.contextWindow)} used, ${Math.round(usage.percent ?? 0)}%). Best available native estimate.`;
-			if (!budget?.enabled) return textResult(`Automatic rollover is disabled (Pi compaction.enabled=false). ${hard}`);
-			if (!budget.supported) return textResult(`${unsupportedMessage(budget)} ${hard}`);
+			if (!budget?.enabled) return textResult(`Automatic rollover is disabled (Pi compaction.enabled=false). ${hard}`, [], display);
+			if (!budget.supported) return textResult(`${unsupportedMessage(budget)} ${hard}`, [], display);
 			return textResult(
 				`≈${n(Math.max(0, budget.rolloverAt - usage.tokens))} tokens until automatic rollover (line at ${n(budget.rolloverAt)}); ${hard}`,
+				[], display,
 			);
 		},
 	});
@@ -838,6 +852,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "notes",
 		label: "Notes",
+		...toolCards("notes"),
 		description:
 			"Persistent notes in .pi/notes/ that survive context resets. Ops: list, read (paged; pass offset to continue), write (create/replace; empty content clears), append, search (case-insensitive substring over note lines). Inside a Git repository, including nested directories and linked worktrees, notes belong to the main checkout.",
 		promptSnippet: "save and recall durable state that survives context resets",
@@ -874,10 +889,10 @@ export default function (pi: ExtensionAPI) {
 
 			switch (params.op) {
 				case "list": {
-					if (!existsSync(dir)) return textResult("(no notes yet)");
+					if (!existsSync(dir)) return textResult("(no notes yet)", [], { kind: "notes-list", count: 0 });
 					const files: string[] = [];
 					walk(dir, files);
-					return textResult(files.length ? files.map((file) => file.slice(dir.length + 1)).join("\n") : "(no notes yet)");
+					return textResult(files.length ? files.map((file) => file.slice(dir.length + 1)).join("\n") : "(no notes yet)", [], { kind: "notes-list", count: files.length });
 				}
 				case "read": {
 					const relative = requireValue(params.path, "path", params.op);
@@ -891,7 +906,7 @@ export default function (pi: ExtensionAPI) {
 					const end = Math.min(text.length, offset + requirePage(nativeContext(ctx), offset, 0, activeToolTokens()));
 					const more =
 						end < text.length ? `\n[chars ${offset}-${end} of ${text.length}; continue with offset ${end}]` : "";
-					return textResult(`${text.slice(offset, end)}${more}`);
+					return textResult(`${text.slice(offset, end)}${more}`, [], { kind: "note-read", offset, end, total: text.length });
 				}
 				case "write": {
 					const relative = requireValue(params.path, "path", params.op);
@@ -899,7 +914,7 @@ export default function (pi: ExtensionAPI) {
 					const path = safeJoin(relative);
 					mkdirSync(dirname(path), { recursive: true });
 					writeFileSync(path, params.content);
-					return textResult(`Wrote .pi/notes/${relative}`);
+					return textResult(`Wrote .pi/notes/${relative}`, [], { kind: "note-write" });
 				}
 				case "append": {
 					const relative = requireValue(params.path, "path", params.op);
@@ -912,11 +927,11 @@ export default function (pi: ExtensionAPI) {
 					const existing = existsSync(path) ? readFileSync(path, "utf8") : "";
 					const separator = existing && !existing.endsWith("\n") ? "\n" : "";
 					appendFileSync(path, `${separator}${content.replace(/\n?$/, "\n")}`);
-					return textResult(`Appended to .pi/notes/${relative}`);
+					return textResult(`Appended to .pi/notes/${relative}`, [], { kind: "note-append" });
 				}
 				case "search": {
 					const query = requireValue(params.query, "query", params.op).toLowerCase();
-					if (!existsSync(dir)) return textResult("(no notes yet)");
+					if (!existsSync(dir)) return textResult("(no notes yet)", [], { kind: "notes-search", count: 0 });
 					const files: string[] = [];
 					walk(dir, files);
 					const hits: string[] = [];
@@ -930,7 +945,7 @@ export default function (pi: ExtensionAPI) {
 							}
 						}
 					}
-					return textResult(hits.length ? hits.join("\n") : `No notes match "${params.query}".`);
+					return textResult(hits.length ? hits.join("\n") : `No notes match "${params.query}".`, [], { kind: "notes-search", count: hits.length });
 				}
 			}
 		},
@@ -939,6 +954,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "history",
 		label: "History",
+		...toolCards("history"),
 		description:
 			"Search or read normalized session entries, including earlier native context windows. Search prioritizes original content before recovery notes, handoffs, and history lookups; all remain searchable. Current branch by default; all=true searches every project session file. Within each group: newest-modified sessions first, newest entries per session. Reads return stored images and page long text with the next offset.",
 		promptSnippet: "recover earlier conversation that left the active context window",
@@ -957,13 +973,13 @@ export default function (pi: ExtensionAPI) {
 			if (params.op === "search") {
 				const query = requireValue(params.query, "query", params.op).toLowerCase();
 				const limit = params.limit ?? 10;
-				const hits: string[][] = [[], []];
+				const hits: HistoryHit[][] = [[], []];
 				// Forks copy ancestor entries under the same ids into new session files; report each id once.
 				const seen = new Set<string>();
 				const addHit = (hit: HistoryHit | undefined) => {
 					if (!hit || seen.has(hit.id) || hits[hit.priority].length >= limit) return;
 					seen.add(hit.id);
-					hits[hit.priority].push(hit.text);
+					hits[hit.priority].push(hit);
 				};
 
 				if (params.all) {
@@ -989,7 +1005,10 @@ export default function (pi: ExtensionAPI) {
 					}
 				}
 				const results = hits.flat().slice(0, limit);
-				return textResult(results.length ? results.join("\n") : `No history matches "${params.query}".`);
+				return textResult(results.length ? results.map((hit) => hit.text).join("\n") : `No history matches "${params.query}".`, [], {
+					kind: "history-search",
+					entries: results.map((hit) => ({ headerLength: hit.headerLength, length: hit.text.length })),
+				});
 			}
 
 			const id = requireValue(params.id, "id", params.op);
@@ -1003,10 +1022,12 @@ export default function (pi: ExtensionAPI) {
 					offset + requirePage(nativeContext(ctx), offset, offset === 0 ? item.images.length : 0, activeToolTokens()),
 				);
 				const more = end < item.text.length ? `\nMore remains; call history read with id "${id}" and offset ${end}.` : "";
+				const header = `${source ? `${source} ` : ""}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${id}] [chars ${offset}-${end} of ${item.text.length}] `;
 				// Stored images ride along with the first page only.
 				return textResult(
-					`${source ? `${source} ` : ""}${item.entry.timestamp ?? ""} [window ${item.windowId}] [${id}] [chars ${offset}-${end} of ${item.text.length}] ${item.text.slice(offset, end)}${more}`,
+					`${header}${item.text.slice(offset, end)}${more}`,
 					offset === 0 ? item.images : [],
+					{ kind: "history-read", headerLength: header.length, offset, end, total: item.text.length },
 				);
 			};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.85.0",
+				"@earendil-works/pi-tui": "0.85.0",
 				"typebox": "1.3.7",
 				"typescript": "^5.5.0"
 			},
@@ -18,10 +19,14 @@
 			},
 			"peerDependencies": {
 				"@earendil-works/pi-coding-agent": "*",
+				"@earendil-works/pi-tui": "*",
 				"typebox": "*"
 			},
 			"peerDependenciesMeta": {
 				"@earendil-works/pi-coding-agent": {
+					"optional": true
+				},
+				"@earendil-works/pi-tui": {
 					"optional": true
 				},
 				"typebox": {
@@ -2448,6 +2453,46 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.85.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.0.tgz",
+			"integrity": "sha512-8+rXIWAfByYOBcEr3v6C64QFUYrcjw9NpHTN+boyUH2c0kPRybFhW58LYUAYvVnMaRw8+l9yCVSc6YCidw7cHw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/typebox": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"url": "git+https://github.com/fitchmultz/pi-posthorse.git"
 	},
 	"license": "MIT",
-	"files": ["index.ts"],
+	"files": ["index.ts", "ui.ts"],
 	"engines": {
 		"node": ">=22.19.0"
 	},
@@ -19,15 +19,19 @@
 	},
 	"scripts": {
 		"check": "tsc --noEmit",
-		"test": "node --test test/posthorse.test.ts",
+		"test": "node --import ./test/pi-loader.ts --test test/*.test.ts",
 		"prepublishOnly": "npm test && npm run check"
 	},
 	"peerDependencies": {
 		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*",
 		"typebox": "*"
 	},
 	"peerDependenciesMeta": {
 		"@earendil-works/pi-coding-agent": {
+			"optional": true
+		},
+		"@earendil-works/pi-tui": {
 			"optional": true
 		},
 		"typebox": {
@@ -36,6 +40,7 @@
 	},
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.85.0",
+		"@earendil-works/pi-tui": "0.85.0",
 		"typebox": "1.3.7",
 		"typescript": "^5.5.0"
 	}

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -14,4 +14,5 @@ target="$agent/test/posthorse-integration.test.ts"
 cp "$here/test/integration/posthorse-in-pi.test.ts" "$target"
 trap 'rm -f "$target"' EXIT
 cd "$agent"
-POSTHORSE_INDEX="$here/index.ts" npx vitest run test/posthorse-integration.test.ts
+NODE_OPTIONS="${NODE_OPTIONS:-} --import=\"$here/test/pi-loader.ts\"" \
+  POSTHORSE_INDEX="$here/index.ts" npx vitest run test/posthorse-integration.test.ts

--- a/test/pi-loader.ts
+++ b/test/pi-loader.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { registerHooks } from "node:module";
+
+// Pi 0.85.0's unbundled entry imports an undeclared pi-server package. Test its
+// shipped native bundle; remove this workaround when updating the pinned SDK.
+const entry = import.meta.resolve("@earendil-works/pi-coding-agent");
+const { version } = JSON.parse(readFileSync(new URL("../package.json", entry), "utf8"));
+if (version !== "0.85.0") throw new Error("Recheck Pi's native test entry before updating the SDK baseline.");
+registerHooks({
+	resolve(specifier, context, nextResolve) {
+		const resolved = nextResolve(specifier, context);
+		return resolved.url === entry ? { ...resolved, url: new URL("bundle/index.js", entry).href } : resolved;
+	},
+});

--- a/test/posthorse.test.ts
+++ b/test/posthorse.test.ts
@@ -51,6 +51,7 @@ function setup() {
 			tools.set(tool.name, tool);
 			toolDefinitions.push(tool);
 		},
+		registerMessageRenderer() {},
 		sendMessage(message: (typeof messages)[number]) {
 			messages.push(message);
 		},
@@ -1006,9 +1007,10 @@ test("appends from concurrent Pi processes never merge records", async () => {
 	try {
 		// Each child loads the real extension and appends 200 records to one shared note as fast as it can.
 		const script = `
+			await import(${JSON.stringify(new URL("./pi-loader.ts", import.meta.url).href)});
 			const { default: posthorse } = await import(${JSON.stringify(new URL("../index.ts", import.meta.url).href)});
 			const tools = new Map();
-			posthorse({ on() {}, registerTool: (tool) => tools.set(tool.name, tool), sendMessage() {} });
+			posthorse({ on() {}, registerTool: (tool) => tools.set(tool.name, tool), registerMessageRenderer() {}, sendMessage() {} });
 			const [cwd, letter] = process.argv.slice(1);
 			const context = { cwd, newContext() {}, getCompactionSettings: () => ({ enabled: true, reserveTokens: 16_384 }), getContextUsage: () => undefined };
 			for (let i = 0; i < 200; i++) {

--- a/test/renderers.test.ts
+++ b/test/renderers.test.ts
@@ -1,0 +1,322 @@
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import {
+	CustomMessageComponent,
+	initTheme,
+	ToolExecutionComponent,
+	type ExtensionAPI,
+	type ExtensionContext,
+	type MessageRenderer,
+	type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, visibleWidth, type TUI, type TuiMouseEvent } from "@earendil-works/pi-tui";
+import posthorse from "../index.ts";
+
+initTheme("dark");
+
+function setup() {
+	const tools = new Map<string, ToolDefinition>();
+	const messages = new Map<string, MessageRenderer>();
+	posthorse({
+		on() {},
+		registerTool: (tool: ToolDefinition) => tools.set(tool.name, tool),
+		registerMessageRenderer: (name: string, renderer: MessageRenderer) => messages.set(name, renderer),
+		getActiveTools: () => [...tools.keys()],
+		getAllTools: () => [...tools.values()],
+	} as unknown as ExtensionAPI);
+	return { tools, messages };
+}
+
+function card(name: string, args: unknown = {}) {
+	const definition = setup().tools.get(name)!;
+	return new ToolExecutionComponent(name, "tool-1", args, {}, definition, { requestRender() {} } as TUI, tmpdir());
+}
+
+function lines(component: { render(width: number): string[] }, width = 80) {
+	const rendered = component.render(width);
+	for (const line of rendered) assert.ok(visibleWidth(line) <= width, `row exceeds ${width} columns`);
+	return rendered.map((line) => stripTerminalSequences(line).trimEnd());
+}
+const text = (component: { render(width: number): string[] }, width = 80) => lines(component, width).join("\n");
+const result = (value: string, details?: unknown, isError = false) => ({
+	content: [{ type: "text", text: value }], details, isError,
+});
+function click(component: { handleMouse(event: TuiMouseEvent): { handled?: boolean } | undefined }, width: number, y: number) {
+	return component.handleMouse({ type: "click", button: "left", x: 2, y, screenX: 2, screenY: y, width, height: 100, shift: false, alt: false, ctrl: false });
+}
+
+function context(cwd: string, branch: unknown[] = []): ExtensionContext {
+	return {
+		cwd,
+		model: { contextWindow: 100_000 },
+		newContext() {},
+		getCompactionSettings: () => ({ enabled: true, reserveTokens: 16_384 }),
+		getContextUsage: () => ({ tokens: 1000, contextWindow: 100_000, percent: 1 }),
+		getSystemPrompt: () => "test",
+		sessionManager: { getBranch: () => branch, getSessionDir: () => cwd },
+	} as unknown as ExtensionContext;
+}
+async function execute(name: string, args: Record<string, unknown>, ctx: ExtensionContext) {
+	return setup().tools.get(name)!.execute("tool-1", args, undefined, undefined, ctx);
+}
+
+test("all four native cards identify pending calls and tolerate malformed streamed arguments", () => {
+	for (const [name, args, expected] of [
+		["notes", { op: "read", path: "plan.md" }, /Notes.*read.*plan\.md/],
+		["history", { op: "search", query: "relay", all: true }, /History.*search.*relay/],
+		["get_context_remaining", {}, /Context/],
+		["new_context", { handoff: "next station" }, /New context/],
+	] as const) {
+		const definition = setup().tools.get(name)!;
+		assert.equal(typeof definition.renderCall, "function", `${name} needs its native call renderer`);
+		assert.equal(typeof definition.renderResult, "function", `${name} needs its native result renderer`);
+		assert.notEqual(definition.renderShell, "self", "Pi owns the card shell and expansion");
+		const component = card(name, args);
+		component.markExecutionStarted();
+		assert.match(text(component), expected);
+		assert.match(text(component), /running/i);
+		for (const malformed of [undefined, null, { op: 3, path: {} }, { query: ["bad"], id: false }]) {
+			component.updateArgs(malformed);
+			assert.ok(lines(component, 24).length <= 6);
+		}
+	}
+});
+
+test("native cards cap actual wrapped rows and expose complete legacy text by click or global expansion", () => {
+	const body = `START ${"界 👩🏽‍💻 é ".repeat(900)} END`;
+	const component = card("notes", { op: "read", path: `${"長".repeat(100)}.md` });
+	component.updateResult(result(body));
+	for (const width of [24, 40, 80, 196]) {
+		const collapsed = text(component, width);
+		assert.ok(lines(component, width).length <= 10, `collapsed height is bounded at ${width}`);
+		assert.match(collapsed, /START/);
+		assert.doesNotMatch(collapsed, / END/);
+	}
+	assert.equal(click(component, 80, 2)?.handled, true);
+	assert.match(text(component), / END/);
+	component.setExpanded(false);
+	assert.doesNotMatch(text(component), / END/);
+	component.setExpanded(true);
+	assert.match(text(component), / END/);
+});
+
+test("notes show page range and next offset even when the preview fills the compact card", async () => {
+	const cwd = mkdtempSync(`${tmpdir()}/posthorse-render-`);
+	try {
+		const ctx = context(cwd);
+		const body = `START ${"n".repeat(56_176)} END`;
+		await execute("notes", { op: "write", path: "ledger.md", content: body }, ctx);
+		const args = { op: "read", path: "ledger.md" };
+		const output = await execute("notes", args, ctx);
+		const snapshot = structuredClone(output);
+		const component = card("notes", args);
+		component.updateResult({ ...output, isError: false });
+		const compact = text(component, 40);
+		assert.match(compact, /0[–-]20,000.*56,186/s);
+		assert.match(compact, /offset 20,000/);
+		assert.ok(lines(component, 40).length <= 10);
+		assert.equal(click(component, 40, 4)?.handled, true, "the visible body also expands");
+		assert.match(text(component), /continue with offset 20000/);
+		assert.deepEqual(output, snapshot, "rendering must not mutate model-visible output");
+		assert.ok(JSON.stringify(output.details).length < 200, "page metadata must not duplicate the note");
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("empty notes, no matches, actual errors, and submitted content stay distinct", async () => {
+	const empty = card("notes", { op: "read", path: "empty.md" });
+	empty.updateResult(result(""));
+	assert.match(text(empty), /Empty note/);
+	const error = card("notes", { op: "read", path: "missing.md" });
+	error.updateResult(result("No note at missing.md. Use list.", undefined, true));
+	assert.match(text(error), /error/i);
+	assert.match(text(error), /No note at missing\.md/);
+	const noMatches = card("history", { op: "search", query: "nothing" });
+	noMatches.updateResult(result('No history matches "nothing".'));
+	assert.match(text(noMatches), /No history matches/);
+	const write = card("notes", { op: "write", path: "draft.md", content: "SUBMITTED TEXT" });
+	write.updateResult(result("Wrote .pi/notes/draft.md"));
+	write.setExpanded(true);
+	assert.match(text(write), /SUBMITTED TEXT/);
+});
+
+test("empty history has one compact summary and keeps the returned text on expansion", async () => {
+	const cwd = mkdtempSync(`${tmpdir()}/posthorse-empty-history-`);
+	try {
+		const args = { op: "search", query: "absent", all: true };
+		const output = await execute("history", args, context(cwd));
+		const component = card("history", args);
+		component.updateResult({ ...output, isError: false });
+		assert.match(text(component), /No matches · all sessions/);
+		assert.doesNotMatch(text(component), /No history matches/);
+		component.setExpanded(true);
+		assert.match(text(component), /No history matches "absent"\./);
+		assert.deepEqual(output.content, [{ type: "text", text: 'No history matches "absent".' }]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("history searches lead with content and retain every entry and recovery identifier expanded", async () => {
+	const branch = Array.from({ length: 30 }, (_, index) => ({
+		type: "message", id: `entry-${index}`, timestamp: "2026-09-06T17:43:46.741Z",
+		message: { role: "user", content: `Relay station ${index}: ${"route details ".repeat(20)}` },
+	}));
+	const args = { op: "search", query: "Relay station", limit: 30 };
+	const output = await execute("history", args, context(tmpdir(), branch));
+	const component = card("history", args);
+	component.updateResult({ ...output, isError: false });
+	assert.match(text(component, 40), /30 matches/);
+	assert.match(text(component, 40), /Relay station 29/);
+	assert.match(text(component, 40), /Relay station 28/);
+	assert.doesNotMatch(text(component, 40), /2026-09-06T17/);
+	assert.ok(lines(component, 40).length <= 10);
+	component.setExpanded(true);
+	const expanded = text(component, 196);
+	for (let index = 0; index < 30; index++) assert.match(expanded, new RegExp(`\\[entry-${index}\\]`));
+	assert.ok(expanded.indexOf("Relay station 29") < expanded.indexOf("2026-09-06T17"));
+	assert.ok(JSON.stringify(output.details).length < 2000, "search display data is numeric boundaries, not copied bodies");
+});
+
+test("context summaries preserve approximation and native disabled, unsupported, unknown states", async () => {
+	for (const [tokens, window, enabled, expected] of [
+		[1000, 100_000, true, /≈.*rollover/],
+		[1000, 100_000, false, /disabled/i],
+		[1000, 8192, true, /unsupported/i],
+		[null, 100_000, true, /unknown|not known/i],
+	] as const) {
+		const ctx = context(tmpdir());
+		Object.assign(ctx, {
+			getContextUsage: () => ({ tokens, contextWindow: window, percent: null }),
+			getCompactionSettings: () => ({ enabled, reserveTokens: 16_384 }),
+		});
+		const output = await execute("get_context_remaining", {}, ctx);
+		const component = card("get_context_remaining");
+		component.updateResult({ ...output, isError: false });
+		assert.match(text(component, 80), expected);
+		assert.doesNotMatch(text(component, 80), /0%/);
+		component.setExpanded(true);
+		assert.ok(text(component, 196).includes("native estimate") || tokens === null);
+	}
+});
+
+test("new_context remains a conditional request and only its committed message says the window started", async () => {
+	const handoff = Array.from({ length: 60 }, (_, i) => `Handoff line ${i + 1}`).join("\n");
+	const args = { handoff };
+	const output = await execute("new_context", args, context(tmpdir()));
+	assert.deepEqual(output.content, [{ type: "text", text: "Requested a fresh Pi context after this complete tool batch succeeds. Earlier conversation stays in session history." }]);
+	const component = card("new_context", args);
+	component.updateResult({ ...output, isError: false });
+	assert.match(text(component), /Requested.*batch succeeds/s);
+	assert.doesNotMatch(text(component), /committed|window started/i);
+	component.setExpanded(true);
+	assert.match(text(component), /Handoff line 60/);
+	const message = {
+		role: "custom" as const, customType: "context-window", display: true, timestamp: 0,
+		details: { windowId: "window-2", tokensBefore: 1000 },
+		content: `Context window window-2 starts here. Earlier conversation is not available in this window.\n\nHandoff from the previous window:\n${handoff}`,
+	};
+	const renderer = setup().messages.get("context-window");
+	assert.equal(typeof renderer, "function");
+	const committed = new CustomMessageComponent(message, renderer, undefined, 0);
+	assert.match(text(committed), /history/);
+	assert.ok(lines(committed, 40).length <= 10);
+	assert.doesNotMatch(text(committed), /Handoff line 60/);
+	assert.equal(click(committed, 80, 2)?.handled, true);
+	assert.match(text(committed), /Handoff line 60/);
+	committed.setExpanded(true);
+	committed.setExpanded(false);
+	assert.doesNotMatch(text(committed), /Handoff line 60/);
+	committed.setExpanded(true);
+	assert.match(text(committed), /Handoff line 60/);
+	assert.equal(click(committed, 80, 4)?.handled, true, "clicking the message body collapses it");
+	assert.doesNotMatch(text(committed), /Handoff line 60/);
+	committed.setOutputPad(2);
+	committed.invalidate();
+	assert.doesNotMatch(text(committed), /Handoff line 60/, "padding/theme invalidation preserves the local choice");
+	assert.equal(message.content.endsWith(handoff), true);
+});
+
+test("native rendering preserves theme changes and leaves drag selection to Pi", () => {
+	const component = card("notes", { op: "read", path: "theme.md" });
+	component.updateResult(result("A readable note"));
+	const before = component.render(80).join("\n");
+	try {
+		initTheme("light");
+		component.invalidate();
+		const after = component.render(80).join("\n");
+		const withoutShellBackground = (value: string) => value.replace(/\x1b\[(?:48;[0-9;]+|49)m/g, "");
+		const noteRow = (value: string) => value.split("\n").find((line) => line.includes("A readable note"))!;
+		assert.notEqual(withoutShellBackground(noteRow(after)), withoutShellBackground(noteRow(before)), "result colors update, not just Pi's shell or title");
+		assert.equal(stripTerminalSequences(after), stripTerminalSequences(before));
+		assert.equal(component.handleMouse({ type: "drag", button: "left", x: 4, y: 3, screenX: 4, screenY: 3, width: 80, height: 10, shift: false, alt: false, ctrl: false }), undefined);
+	} finally {
+		initTheme("dark");
+	}
+});
+
+test("partial and error results cannot inherit a success summary or terminal controls", () => {
+	const controls = "\x1b[2J\x1b]52;c;c2VjcmV0\x07\x1b_hidden\x1b\\\x00\r";
+	const component = card("notes", { op: "write", path: `draft${controls}.md`, content: `saved${controls}` });
+	component.updateResult(result(`still running${controls}`, { kind: "note-write" }), true);
+	assert.match(text(component), /still running/);
+	assert.doesNotMatch(text(component), /Saved note/);
+	component.updateResult(result(`ERROR HEAD ${"problem ".repeat(100)} ERROR TAIL${controls}`, { kind: "note-write" }, true));
+	assert.match(text(component), /ERROR HEAD/);
+	assert.doesNotMatch(text(component), /Saved note/);
+	component.setExpanded(true);
+	assert.match(text(component), /ERROR TAIL/);
+	assert.doesNotMatch(component.render(80).join("\n"), /\x1b\[2J|\x1b\]52|hidden|\x00|\r/);
+});
+
+test("history pages keep paging, metadata, and native image attachments without copied bodies", async () => {
+	const image = { type: "image", mimeType: "image/png", data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==" };
+	const body = `ENTRY HEAD ${"route ".repeat(5000)} ENTRY TAIL`;
+	const branch = [{ type: "message", id: "picture-entry", timestamp: "2026-09-06T17:43:46Z", message: { role: "user", content: [{ type: "text", text: body }, image] } }];
+	const args = { op: "read", id: "picture-entry" };
+	const output = await execute("history", args, context(tmpdir(), branch));
+	const component = card("history", args);
+	component.updateResult({ ...output, isError: false });
+	component.setShowImages(false);
+	assert.match(text(component, 40), /Next offset 20,000/);
+	assert.match(text(component, 40), /1 image attached/);
+	assert.ok(lines(component, 40).length <= 10);
+	assert.deepEqual(output.content.slice(1), [image]);
+	assert.ok(JSON.stringify(output.details).length < 200);
+	component.setExpanded(true);
+	const expanded = text(component, 196);
+	assert.ok(expanded.indexOf("ENTRY HEAD") < expanded.indexOf("2026-09-06T17"));
+	assert.match(expanded, /\[picture-entry\]/);
+	assert.match(expanded, /More remains; call history read/);
+	const continuation = await execute("history", { ...args, offset: 20_000 }, context(tmpdir(), branch));
+	assert.equal(continuation.content.length, 1);
+});
+
+test("legacy history and malformed display spans fall back to the complete returned text", () => {
+	const raw = "archive.jsonl 2026-09-06T17:43:46Z [window old] [owner-1] [user] Relay station is ready.\nSECOND LINE";
+	for (const details of [undefined, { kind: "history-search", entries: [{ headerLength: 99_999, length: 3 }] }]) {
+		const component = card("history", { op: "search", query: "Relay station" });
+		component.updateResult(result(raw, details));
+		assert.match(text(component, 40), /Relay station/);
+		assert.ok(lines(component, 40).length <= 10);
+		component.setExpanded(true);
+		for (const line of raw.split("\n")) assert.ok(text(component, 196).includes(line));
+	}
+});
+
+test("owned reminders are compact, expandable, and sanitize terminal control content", () => {
+	for (const customType of ["posthorse-reminder", "headroom-reminder"]) {
+		const renderer = setup().messages.get(customType);
+		assert.equal(typeof renderer, "function");
+		const message = { role: "custom" as const, customType, display: true, timestamp: 0, content: `Checkpoint now\n${"remember\n".repeat(50)}LAST\x1b[2J\x1b]52;c;c2VjcmV0\x07\x00` };
+		const component = new CustomMessageComponent(message, renderer, undefined, 2);
+		assert.ok(lines(component, 24).length <= 10);
+		component.setExpanded(true);
+		assert.match(text(component), /LAST/);
+		const raw = component.render(80).join("\n");
+		assert.doesNotMatch(raw, /\x1b\[2J|\x1b\]52|\x00/);
+	}
+});

--- a/ui.ts
+++ b/ui.ts
@@ -1,0 +1,180 @@
+import { keyText, type ExtensionAPI, type MessageRenderer, type Theme, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Box, MouseRegion, Text, stripTerminalSequences, truncateToWidth, type Component } from "@earendil-works/pi-tui";
+
+/** Display-only facts and offsets into content, never a second copy of a note or history page. */
+export type PosthorseDisplay =
+	| { kind: "context"; usage?: { tokens: number | null; contextWindow: number; percent: number | null }; rollover?: "enabled" | "disabled" | "unsupported"; rolloverAt?: number }
+	| { kind: "notes-list" | "notes-search"; count: number }
+	| { kind: "note-read"; offset: number; end: number; total: number }
+	| { kind: "note-write" | "note-append" | "new-context" }
+	| { kind: "history-search"; entries: Array<{ headerLength: number; length: number }> }
+	| { kind: "history-read"; headerLength: number; offset: number; end: number; total: number };
+
+type ToolName = "notes" | "history" | "get_context_remaining" | "new_context";
+const titles: Record<ToolName, string> = { notes: "Notes", history: "History", get_context_remaining: "Context budget", new_context: "New context" };
+const n = (value: number) => value.toLocaleString("en-US");
+
+function clean(value: string): string {
+	return stripTerminalSequences(value).replace(/[\x00-\x08\x0b-\x1f\x7f-\x9f\ufff9-\ufffb]/g, "");
+}
+function argsOf(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+function argument(value: unknown, name: string): string {
+	return typeof value === "string" ? clean(value) : value == null ? "…" : `[invalid ${name}]`;
+}
+function textOf(content: unknown): string {
+	if (typeof content === "string") return content;
+	return Array.isArray(content) ? content.filter((part) => part?.type === "text" && typeof part.text === "string").map((part) => part.text).join("\n") : "";
+}
+function textBlock(text: string, theme: Theme, color: "toolOutput" | "muted" | "dim" | "error" | "warning" = "toolOutput"): Text {
+	return new Text(text ? theme.fg(color, clean(text)) : "", 0, 0);
+}
+function hint(theme: Theme, width: number): string {
+	const key = keyText("app.tools.expand");
+	return truncateToWidth(theme.fg("dim", key ? `… ${key} to expand` : "… details hidden"), width);
+}
+function pageSummary(page: { offset: number; end: number; total: number }): string {
+	if (!page.total) return "Empty note";
+	if (!page.offset && page.end === page.total) return `${n(page.total)} chars · complete`;
+	return `Chars ${n(page.offset)}–${n(page.end)} of ${n(page.total)}${page.end < page.total ? `\nNext offset ${n(page.end)}` : " · final page"}`;
+}
+
+function historySections(raw: string, display: PosthorseDisplay | undefined): Array<{ body: string; header: string }> | undefined {
+	const spans = display?.kind === "history-search" ? display.entries : display?.kind === "history-read" ? [{ headerLength: display.headerLength, length: raw.length }] : undefined;
+	if (!Array.isArray(spans) || !spans.length) return undefined;
+	let start = 0;
+	const sections: Array<{ body: string; header: string }> = [];
+	for (const span of spans) {
+		if (!Number.isInteger(span.headerLength) || !Number.isInteger(span.length) || span.headerLength < 0 || span.headerLength > span.length || start + span.length > raw.length) return undefined;
+		sections.push({ header: raw.slice(start, start + span.headerLength).trimEnd(), body: raw.slice(start + span.headerLength, start + span.length) });
+		start += span.length + 1;
+	}
+	return start === raw.length + 1 ? sections : undefined;
+}
+
+export function toolCards(name: ToolName): Pick<ToolDefinition, "renderCall" | "renderResult"> {
+	return {
+		renderCall(rawArgs, theme, context) {
+			const args = argsOf(rawArgs);
+			const action = name === "notes" || name === "history" ? ` · ${argument(args.op, "op")}` : name === "new_context" ? " · request" : "";
+			const status = context.isError ? " · error" : context.isPartial ? context.executionStarted ? " · running" : " · preparing" : "";
+			const target = args.op === "search" ? ` · “${argument(args.query, "query")}”` : name === "notes" && args.op !== "list" ? ` · ${argument(args.path, "path")}` : name === "history" && args.op === "read" ? ` · ${argument(args.id, "id")}` : "";
+			const label = `${context.isPartial ? "…" : context.expanded ? "▾" : "▸"} ${titles[name]}${action}${status}${target}`;
+			return {
+				invalidate() {},
+				render(width) {
+					const heading = theme.fg(context.isError ? "error" : "toolTitle", theme.bold(label));
+					if (!context.expanded) return [truncateToWidth(heading.replace(/\s+/g, " "), width)];
+					const details = [
+						name === "history" && args.op === "search" ? `Scope: ${args.all === true ? "all project sessions" : "current branch"}` : "",
+						args.offset !== undefined ? `Offset: ${typeof args.offset === "number" ? n(args.offset) : "[invalid offset]"}` : "",
+						args.limit !== undefined ? `Limit: ${typeof args.limit === "number" ? n(args.limit) : "[invalid limit]"}` : "",
+					].filter(Boolean).join(" · ");
+					return [...new Text(heading, 0, 0).render(width), ...textBlock(details, theme, "muted").render(width)];
+				},
+			};
+		},
+		renderResult(result, { expanded, isPartial }, theme, context) {
+			const args = argsOf(context.args);
+			const raw = textOf(result.content);
+			const display = result.details as PosthorseDisplay | undefined;
+			const sections = !context.isError && !isPartial ? historySections(raw, display) : undefined;
+			let summary = "";
+			let body = raw;
+			let color: "toolOutput" | "warning" | "error" = context.isError ? "error" : "toolOutput";
+			if (!context.isError && !isPartial) {
+				switch (display?.kind) {
+					case "context": {
+						const usage = display.usage;
+						if (!usage || usage.tokens == null) { summary = "Context usage unknown"; break; }
+						const hard = `≈${n(Math.max(0, usage.contextWindow - usage.tokens))} tokens to hard limit`;
+						const rollover = display.rollover === "enabled" && display.rolloverAt !== undefined ? `≈${n(Math.max(0, display.rolloverAt - usage.tokens))} tokens to rollover` : `Automatic rollover ${display.rollover ?? "unknown"}`;
+						summary = `${rollover}\n${hard}\n≈${n(usage.tokens)} / ${n(usage.contextWindow)} used${usage.percent == null ? "" : ` (≈${Math.round(usage.percent)}%)`}`;
+						if (display.rollover === "unsupported") color = "warning";
+						break;
+					}
+					case "notes-list": summary = display.count ? `${n(display.count)} note${display.count === 1 ? "" : "s"}` : "No notes yet"; break;
+					case "notes-search": summary = display.count ? `${n(display.count)} matches returned` : "No matches"; break;
+					case "note-read": summary = pageSummary(display); break;
+					case "note-write": summary = args.content === "" ? "Cleared note" : "Saved note"; break;
+					case "note-append": summary = "Appended to note"; break;
+					case "history-search": if (Array.isArray(display.entries) && (!display.entries.length || sections)) summary = `${display.entries.length ? `${n(display.entries.length)} matches` : "No matches"} · ${args.all === true ? "all sessions" : "current branch"}`; break;
+					case "history-read": summary = pageSummary(display); break;
+					case "new-context": summary = "Requested for after the whole tool batch succeeds."; break;
+				}
+			}
+			if (!body.trim()) body = context.isError ? "No error details returned." : isPartial ? "Running…" : name === "notes" && args.op === "read" ? "Empty note" : "No text returned.";
+			const submitted = name === "new_context" && typeof args.handoff === "string" ? `Handoff supplied:\n${args.handoff}` : name === "notes" && (args.op === "write" || args.op === "append") && typeof args.content === "string" ? `Submitted content:\n${args.content || "(empty)"}` : "";
+			const images = Array.isArray(result.content) ? result.content.filter((part) => part.type === "image") : [];
+			const attachment = images.length ? `${images.length} image${images.length === 1 ? "" : "s"} attached${context.showImages ? "" : " (display hidden)"}` : "";
+			const fullText = sections ? new Text(sections.map(({ body, header }) => `${theme.fg("toolOutput", clean(body))}\n${theme.fg("dim", clean(header))}`).join("\n\n"), 0, 0) : textBlock(body, theme, color);
+			const summaryText = textBlock(summary, theme, color);
+			const submittedText = textBlock(submitted, theme);
+			const attachmentText = textBlock(attachment, theme, "muted");
+			// Old results have no spans. Only the preview sheds the known history prefix.
+			const preview = sections ? sections.map(({ body }) => body).join("\n") : name === "history" && !context.isError ? body.replace(/^[^\n]*?\[window [^\]\n]+\] \[[^\]\n]+\](?: \[chars \d+-\d+ of \d+\])? /gm, "") : body;
+			const previewText = textBlock(preview, theme, color);
+			const searchPreviews = sections && display?.kind === "history-search" ? sections.slice(0, 3).map(({ body }) => theme.fg("toolOutput", clean(body).replace(/\s+/g, " "))) : undefined;
+			const summaryOnly = display?.kind === "context" || display?.kind === "new-context" || display?.kind === "note-write" || display?.kind === "note-append" || ((display?.kind === "notes-list" || display?.kind === "notes-search") && display.count === 0) || (display?.kind === "note-read" && display.total === 0) || (display?.kind === "history-search" && Array.isArray(display.entries) && display.entries.length === 0);
+			return {
+				invalidate() {},
+				render(width) {
+					if (expanded) {
+						return [...fullText.render(width), ...attachmentText.render(width), ...(submitted ? ["", ...submittedText.render(width)] : [])];
+					}
+					const summaryRows = summaryText.render(width).slice(0, 5);
+					const previewRows = summaryOnly && !context.isError && !isPartial ? [] : searchPreviews
+						? searchPreviews.map((line) => truncateToWidth(line, width))
+						: previewText.render(width);
+					const shown = previewRows.slice(0, Math.max(0, Math.min(3, 5 - summaryRows.length - (attachment ? 1 : 0))));
+					const hidden = summaryOnly || previewRows.length > shown.length || Boolean(sections || submitted);
+					return [...summaryRows, ...shown, ...(attachment ? [truncateToWidth(theme.fg("muted", attachment), width)] : []), ...(hidden ? [hint(theme, width)] : [])];
+				},
+			};
+		},
+	};
+}
+
+export function registerPosthorseMessages(pi: ExtensionAPI): void {
+	const states = new WeakMap<object, { global: boolean; expanded: boolean }>();
+	const renderer: MessageRenderer = (message, options, theme) => {
+		let state = states.get(message);
+		if (!state || state.global !== options.expanded) {
+			state = { global: options.expanded, expanded: options.expanded };
+			states.set(message, state);
+		}
+		const view = state;
+		const window = message.customType === "context-window";
+		const raw = textOf(message.content);
+		const handoffLabel = "\n\nHandoff from the previous window:\n";
+		const handoffAt = raw.indexOf(handoffLabel);
+		const preview = window ? handoffAt < 0 ? "" : raw.slice(handoffAt + handoffLabel.length) : raw;
+		const fullText = textBlock(raw, theme);
+		const previewText = textBlock(preview, theme);
+		const historyText = textBlock("Earlier conversation remains in history.", theme, "muted");
+		const content: Component = {
+			invalidate() {},
+			render(width) {
+				const padding = Math.min(options.outputPad, Math.max(0, Math.floor((width - 1) / 2)));
+				const inner = Math.max(1, width - padding * 2);
+				const title = `${view.expanded ? "▾" : "▸"} ${window ? "Context window started" : "Checkpoint reminder"}`;
+				const heading = truncateToWidth(theme.fg(window ? "customMessageLabel" : "warning", theme.bold(title)), inner);
+				const body = view.expanded ? fullText.render(inner) : [
+					...(window ? historyText.render(inner).slice(0, 2) : []),
+					...previewText.render(inner).slice(0, window ? 2 : 3),
+					hint(theme, inner),
+				];
+				const box = new Box(padding, 1, (line) => theme.bg("customMessageBg", line));
+				box.addChild({ render: () => [heading, ...body], invalidate() {} });
+				return box.render(width);
+			},
+		};
+		return new MouseRegion(content, (event) => {
+			if (event.type !== "click" || event.button !== "left") return undefined;
+			view.expanded = !view.expanded;
+			return { handled: true };
+		});
+	};
+	for (const type of ["context-window", "posthorse-reminder", "headroom-reminder"]) pi.registerMessageRenderer(type, renderer);
+}


### PR DESCRIPTION
## Summary

- Add native expandable cards for all four Posthorse tools, with clear actions/targets, compact previews, and visible paging, empty, and error states.
- Keep committed context-window handoffs and checkpoint reminders compact until expanded. Reuse Pi's tool shell, mouse handling, and configured expansion shortcut.
- Preserve model-visible tool text, schemas, notes/history content, and rollover policy. Display metadata contains counts and text boundaries, not copied pages.

## Validation

- Clean-tree tests: 39 passing on Node 22.19 and 24, plus typecheck, package dry-run, and zero audit findings.
- Nine native integration tests pass locally in a disposable clone of the current Pi 0.85.1 fork. CI retains the existing Pi 0.85.0 / `f9b0617` baseline.
- Native renderer regression checks include broken/fixed runs; 35 baseline comparisons preserve model-visible outputs and policy behavior.
- Inspected the actual Pi 0.85.1 TUI using synthetic notes/history: fullscreen and regular mode, wide/narrow layouts, header/body clicks, keyboard expansion, pending/empty/error states, page offsets, handoffs, and a failed sibling batch. The final 25.5-second recording and contact sheets were reviewed.

The SDK 0.85.0 test loader uses its shipped native bundle to avoid an undeclared server import; production imports remain public. No Pi-core changes or baseline bump.
