### PR TITLE
Release Posthorse 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.5
 
 - Adds native expandable cards for context budgets, notes, history, and context requests, with compact previews, result counts, and visible page ranges and continuation offsets.
 - Keeps committed context-window handoffs and checkpoint reminders compact until expanded. Model-visible tool text, prompts, context policy, and stored note/history content are unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-posthorse",
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-posthorse",
-			"version": "0.4.4",
+			"version": "0.4.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.85.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-posthorse",
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"type": "module",
 	"description": "Posthorse: fresh context, same journey. Native no-summary context windows for the fitchmultz/pi fork, with sparse budget reminders, handoffs, notes, and history.",
 	"keywords": ["pi-package", "pi-extension", "context", "posthorse", "rollover"],


### PR DESCRIPTION
## Summary

- Prepare `pi-posthorse` 0.4.5 following the merged native-card work in #12.
- Update only the package/root lockfile versions and the changelog heading.
- No runtime, dependency, or Pi 0.85.0 baseline changes.

## Validation

- 39 tests, typecheck, and hook-free package dry-run pass.
- Structural comparison confirms every non-version package/lockfile field and all runtime files are unchanged.

Tag push, GitHub Release, and npm publication remain held until the merged release commit's exact retained artifact passes isolated install/resource checks and review.
