### PR TITLE
Add isolated Codex recovery prototype and runtime acceptance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,52 @@ jobs:
         working-directory: pi
       - run: PI_FORK=../pi scripts/integration.sh
         working-directory: pi-posthorse
+
+  codex-adapter:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ["22.19", "24"]
+    defaults:
+      run:
+        working-directory: adapters/codex-posthorse
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: adapters/codex-posthorse/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npm test
+      - run: npm audit
+
+  codex-runtime:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: adapters/codex-posthorse
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: adapters/codex-posthorse/package-lock.json
+      - run: npm ci --ignore-scripts
+      - name: Download the pinned Codex runtime
+        run: |
+          curl --fail --location --retry 2 https://github.com/openai/codex/releases/download/rust-v0.153.4/codex-x86_64-unknown-linux-musl.tar.gz -o "$RUNNER_TEMP/codex-runtime.tar.gz"
+          mkdir -p "$RUNNER_TEMP/codex-runtime"
+          tar -xzf "$RUNNER_TEMP/codex-runtime.tar.gz" -C "$RUNNER_TEMP/codex-runtime"
+          "$RUNNER_TEMP/codex-runtime/codex-x86_64-unknown-linux-musl" --version
+      - name: Characterize real runtime behavior
+        env:
+          POSTHORSE_CODEX_BIN: ${{ runner.temp }}/codex-runtime/codex-x86_64-unknown-linux-musl
+        run: npm run test:runtime
+      - name: Save runtime evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-runtime-evidence
+          path: ~/Library/Caches/pi-runs/posthorse-codex-*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Native, no-summary context windows for the [`fitchmultz/pi`](https://github.com/
 
 Pi owns the persisted boundary. Posthorse owns the policy: stable window guidance, one best-effort checkpoint reminder, `new_context`, `get_context_remaining`, durable `notes`, and window-aware `history`. A rollover removes the old window from active model context while the JSONL transcript stays append-only and complete.
 
+An isolated [Codex prototype](adapters/codex-posthorse/README.md) tests local notes and recovery with Codex's native context reset. It is not ready for everyday use and is not included in the Pi package.
+
 ## Requirements
 
 - Node `>=22.19.0`.

--- a/adapters/codex-posthorse/.codex-plugin/plugin.json
+++ b/adapters/codex-posthorse/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "codex-posthorse",
+  "version": "0.1.0",
+  "description": "Local notes, transcript history, and rollover recovery for the isolated Codex Posthorse prototype.",
+  "author": {
+    "name": "Mitch Fultz"
+  },
+  "repository": "https://github.com/fitchmultz/pi-posthorse",
+  "license": "MIT",
+  "interface": {
+    "displayName": "Codex Posthorse",
+    "shortDescription": "Prototype local context recovery for Codex.",
+    "longDescription": "An isolated prototype of Posthorse's local notes, searchable history, and deterministic rollover recovery. Native behavior is checked separately before use with real tasks.",
+    "developerName": "Mitch Fultz",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": "Save a checkpoint of the current task in Posthorse notes."
+  },
+  "mcpServers": "./.mcp.json"
+}

--- a/adapters/codex-posthorse/.mcp.json
+++ b/adapters/codex-posthorse/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "notes": {
+      "command": "node",
+      "args": ["${CODEX_PLUGIN_ROOT}/server.mjs"]
+    }
+  }
+}

--- a/adapters/codex-posthorse/README.md
+++ b/adapters/codex-posthorse/README.md
@@ -1,0 +1,68 @@
+# Codex Posthorse prototype
+
+An isolated proof of Posthorse-style context recovery using Codex's existing local context-reset path, a local tool server, and hooks. It does not replace Pi Posthorse, change the Pi package, or enable Codex's account-gated remote context-management service.
+
+**Not ready for everyday tasks.** Automatic recovery and restart work in controlled real-runtime tests, but stock Codex does not meet all Posthorse requirements. Nothing here installs itself, changes your normal Codex configuration, or replaces the desktop runtime.
+
+## What has been proved
+
+Tests run the actual Codex `0.153.4` app-server, actual command tools, actual hooks, and the actual local MCP server. A local HTTP fixture supplies scripted model replies and usage counts. No real model inference or account credentials are involved.
+
+| Requirement | Observed result with Codex 0.153.4 |
+| --- | --- |
+| Automatic reset keeps original requests and unread tool output recoverable | Pass: the next model request contains recovery text from the local notes bridge after the native window changes. |
+| Notes and original history survive restart | Pass: real tool calls read the saved note and original tool output after restarting the runtime. |
+| A handled checkpoint-write failure stops reset | Pass: an actual filesystem error stops the turn before any context boundary is committed. |
+| Manual `/compact` keeps ordinary summarization | Fail: local token-budget mode resets without a summary request; ordinary mode makes one. |
+| A failed command beside `new_context` cancels reset | Fail: a command exits 7, but the window still changes. Its error remains recoverable. |
+| A failed MCP tool beside `new_context` cancels reset | Fail: Codex reports the tool as failed, but the window still changes. |
+
+The fixture selects the `gpt-6-astra` model identifier. This proves runtime wiring, not Astra's behavior, a 500,000-token workload, or usability inside the desktop app. The tests use a 50,000-token configured window and synthetic usage crossing a 9,000-token threshold to make rollover reproducible.
+
+## How recovery works
+
+1. `SessionStart` and `SubagentStart` register the current task's original transcript path. A child uses its own `agent_id`; `session_id` remains the root task ID.
+2. `PreCompact` saves a bounded recovery record before the runtime resets context. It prioritizes the first and latest original inputs, then trailing tool results, with record IDs for retrieving omitted material. It does not turn assistant progress claims into completed state.
+3. Codex starts a new native context window and calls `notes.thread_hint`. The hint restores task identity, recovery text, and instructions for reading durable notes and original history.
+4. Notes and checkpoints remain on disk. History reads the original Codex JSONL transcript without rewriting or deleting it.
+
+The recovery record is capped at 20,000 characters, with individual excerpts capped at 4,000. Full records remain available in pages. Older summaries are not copied into new recovery records. Child task prompts are labeled as delegated input, not promoted to direct user authorization.
+
+Codex does not persist exact model acknowledgement of each tool result. The adapter infers unread results from the recorded tool batch and subsequent assistant output, and labels that inference explicitly. Recovery text is a record of inputs, not proof that work succeeded; the model must read notes and verify current state before continuing external actions.
+
+## Tools and storage
+
+- `notes`: `list`, `read`, `write`, `append`, `search`. Notes are task-local, not repository-shared like Pi Posthorse. Writes atomically replace a note; append writes one newline-terminated record. Parallel appends are tested.
+- `history`: `list`, `search`, `read`, optionally filtered by native `windowId`. Reads return original JSONL, including metadata, in character-offset pages. Stored image blocks are returned with the first page.
+- `thread_hint`: used by the native recovery bridge. It uses Codex's `_meta.threadId` when supplied, otherwise an explicit `threadId` argument.
+
+`POSTHORSE_STATE_DIR` selects the state directory. Without it, the adapter uses `posthorse` under `CODEX_HOME`, or under `~/.codex` if `CODEX_HOME` is unset. It stores task manifests, immutable checkpoint files, and plaintext notes. Original transcripts stay where Codex created them. Removing the adapter does not remove this data.
+
+The tool server does not make network requests. Returned notes and history become part of the active model's context; real use would therefore send retrieved content to that model's provider. History may include user text, assistant text, recorded reasoning summaries, tool arguments, results, and images. Encrypted reasoning cannot be recovered as plaintext.
+
+## Run the isolated tests
+
+Requirements: Node `>=22.19.0`, and Codex `0.153.4` for runtime tests. From this directory:
+
+```bash
+npm ci --ignore-scripts
+npm test
+npm run test:runtime
+npm run test:acceptance
+```
+
+Set `POSTHORSE_CODEX_BIN` to an explicit executable path to test a different runtime. The last command currently exits nonzero on stock `0.153.4`: two runtime scenarios pass and three fail the required acceptance checks. This is intentional and must not be read as approval to enable the prototype.
+
+`test:runtime` checks wiring and records the observed native behavior, printing `UNMET ACCEPTANCE` for known gaps. CI runs that characterization suite so platform changes and broken wiring are visible. **Green CI does not mean full Posthorse behavior is supported.** `test:acceptance` enforces the stronger requirements and is the readiness check.
+
+Each runtime case creates a separate `CODEX_HOME`, workspace, and state directory under `~/Library/Caches/pi-runs/posthorse-codex-*`, even on Linux. It never imports the normal Codex configuration or credentials. The harness trusts only its own test hooks, uses a loopback model endpoint, and terminates only processes it started. Transcripts, model requests, runtime events, errors, and `acceptance.json` results remain there for inspection; tests do not remove them. Unit and MCP test scratch data is retained under the same cache root.
+
+## Integration limits
+
+The plugin manifest and companion hook/MCP files are a scaffold, not a tested desktop installation path. The native bridge currently looks for a direct MCP server named `notes`; a plugin-namespaced server is not enough to assume it will connect. Runtime tests register that direct server explicitly in the isolated configuration and disable the remote history/notes extension.
+
+Handled hook errors return `continue: false` while exiting successfully, because stock Codex can proceed after a bare hook process failure. A crash, import failure, or timeout can still allow reset without a fresh checkpoint. `SubagentStart` also ignores stop requests, so a failed child registration cannot prevent the child from starting. These are runtime limitations, not fixed by the adapter.
+
+This prototype does not add Pi's proactive checkpoint reminder, context-aware page sizing, shared repository notes, or custom tool cards. Parent/child storage separation is tested at the store layer; a real multi-agent rollover and the installed desktop plugin path have not been tested.
+
+Full Posthorse behavior needs changes in the Codex runtime: retain ordinary manual summarization, cancel a pending explicit reset when its tool batch fails, and stop safely when required checkpoint hooks cannot run. The prototype uses the stock runtime and does not include or install those changes.

--- a/adapters/codex-posthorse/hooks/hooks.json
+++ b/adapters/codex-posthorse/hooks/hooks.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEX_PLUGIN_ROOT}/scripts/session-start.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEX_PLUGIN_ROOT}/scripts/session-start.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEX_PLUGIN_ROOT}/scripts/precompact.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/adapters/codex-posthorse/package-lock.json
+++ b/adapters/codex-posthorse/package-lock.json
@@ -1,0 +1,1202 @@
+{
+  "name": "codex-posthorse",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-posthorse",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.30.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://socket-firewall.workos.dev/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://socket-firewall.workos.dev/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://socket-firewall.workos.dev/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://socket-firewall.workos.dev/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://socket-firewall.workos.dev/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://socket-firewall.workos.dev/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://socket-firewall.workos.dev/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://socket-firewall.workos.dev/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://socket-firewall.workos.dev/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://socket-firewall.workos.dev/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://socket-firewall.workos.dev/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://socket-firewall.workos.dev/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://socket-firewall.workos.dev/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://socket-firewall.workos.dev/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall.workos.dev/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://socket-firewall.workos.dev/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall.workos.dev/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://socket-firewall.workos.dev/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://socket-firewall.workos.dev/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://socket-firewall.workos.dev/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://socket-firewall.workos.dev/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://socket-firewall.workos.dev/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://socket-firewall.workos.dev/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://socket-firewall.workos.dev/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://socket-firewall.workos.dev/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://socket-firewall.workos.dev/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://socket-firewall.workos.dev/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://socket-firewall.workos.dev/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://socket-firewall.workos.dev/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://socket-firewall.workos.dev/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://socket-firewall.workos.dev/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall.workos.dev/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://socket-firewall.workos.dev/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://socket-firewall.workos.dev/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://socket-firewall.workos.dev/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://socket-firewall.workos.dev/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://socket-firewall.workos.dev/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://socket-firewall.workos.dev/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://socket-firewall.workos.dev/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://socket-firewall.workos.dev/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://socket-firewall.workos.dev/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://socket-firewall.workos.dev/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://socket-firewall.workos.dev/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://socket-firewall.workos.dev/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://socket-firewall.workos.dev/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://socket-firewall.workos.dev/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://socket-firewall.workos.dev/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://socket-firewall.workos.dev/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://socket-firewall.workos.dev/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://socket-firewall.workos.dev/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://socket-firewall.workos.dev/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://socket-firewall.workos.dev/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://socket-firewall.workos.dev/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://socket-firewall.workos.dev/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://socket-firewall.workos.dev/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://socket-firewall.workos.dev/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://socket-firewall.workos.dev/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://socket-firewall.workos.dev/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://socket-firewall.workos.dev/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://socket-firewall.workos.dev/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://socket-firewall.workos.dev/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://socket-firewall.workos.dev/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://socket-firewall.workos.dev/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://socket-firewall.workos.dev/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://socket-firewall.workos.dev/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://socket-firewall.workos.dev/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://socket-firewall.workos.dev/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://socket-firewall.workos.dev/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://socket-firewall.workos.dev/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://socket-firewall.workos.dev/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://socket-firewall.workos.dev/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://socket-firewall.workos.dev/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall.workos.dev/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall.workos.dev/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://socket-firewall.workos.dev/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://socket-firewall.workos.dev/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://socket-firewall.workos.dev/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://socket-firewall.workos.dev/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://socket-firewall.workos.dev/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://socket-firewall.workos.dev/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://socket-firewall.workos.dev/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://socket-firewall.workos.dev/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://socket-firewall.workos.dev/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://socket-firewall.workos.dev/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/adapters/codex-posthorse/package-lock.json
+++ b/adapters/codex-posthorse/package-lock.json
@@ -17,7 +17,7 @@
     },
     "node_modules/@hono/node-server": {
       "version": "2.1.1",
-      "resolved": "https://socket-firewall.workos.dev/@hono/node-server/-/node-server-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
       "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
       "license": "MIT",
       "engines": {
@@ -29,7 +29,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
-      "resolved": "https://socket-firewall.workos.dev/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
       "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
@@ -69,7 +69,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/accepts/-/accepts-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
@@ -82,7 +82,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://socket-firewall.workos.dev/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
@@ -98,7 +98,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://socket-firewall.workos.dev/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
@@ -115,7 +115,7 @@
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
-      "resolved": "https://socket-firewall.workos.dev/body-parser/-/body-parser-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
@@ -139,7 +139,7 @@
     },
     "node_modules/body-parser/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -152,7 +152,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://socket-firewall.workos.dev/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
@@ -161,7 +161,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://socket-firewall.workos.dev/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -174,7 +174,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://socket-firewall.workos.dev/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
@@ -190,7 +190,7 @@
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
-      "resolved": "https://socket-firewall.workos.dev/content-disposition/-/content-disposition-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
@@ -203,7 +203,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
@@ -212,7 +212,7 @@
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://socket-firewall.workos.dev/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
@@ -221,7 +221,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://socket-firewall.workos.dev/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
@@ -230,7 +230,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
-      "resolved": "https://socket-firewall.workos.dev/cors/-/cors-2.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
@@ -247,7 +247,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://socket-firewall.workos.dev/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -261,7 +261,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://socket-firewall.workos.dev/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
@@ -278,7 +278,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
@@ -287,7 +287,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall.workos.dev/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -301,13 +301,13 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://socket-firewall.workos.dev/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
@@ -316,7 +316,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall.workos.dev/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -325,7 +325,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://socket-firewall.workos.dev/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -334,7 +334,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
-      "resolved": "https://socket-firewall.workos.dev/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
@@ -346,13 +346,13 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://socket-firewall.workos.dev/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://socket-firewall.workos.dev/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
@@ -361,7 +361,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://socket-firewall.workos.dev/eventsource/-/eventsource-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
       "dependencies": {
@@ -373,7 +373,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.1.1",
-      "resolved": "https://socket-firewall.workos.dev/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
       "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
@@ -382,7 +382,7 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://socket-firewall.workos.dev/express/-/express-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
@@ -425,7 +425,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.7.0",
-      "resolved": "https://socket-firewall.workos.dev/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
       "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
       "license": "MIT",
       "dependencies": {
@@ -444,13 +444,13 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://socket-firewall.workos.dev/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.7",
-      "resolved": "https://socket-firewall.workos.dev/fast-uri/-/fast-uri-3.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
       "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
@@ -466,7 +466,7 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://socket-firewall.workos.dev/finalhandler/-/finalhandler-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
@@ -487,7 +487,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://socket-firewall.workos.dev/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
@@ -496,7 +496,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/fresh/-/fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
@@ -505,7 +505,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://socket-firewall.workos.dev/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -514,7 +514,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://socket-firewall.workos.dev/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -538,7 +538,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall.workos.dev/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -551,7 +551,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://socket-firewall.workos.dev/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -563,7 +563,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://socket-firewall.workos.dev/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -575,7 +575,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://socket-firewall.workos.dev/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -587,7 +587,7 @@
     },
     "node_modules/hono": {
       "version": "4.13.7",
-      "resolved": "https://socket-firewall.workos.dev/hono/-/hono-4.13.7.tgz",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
       "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
@@ -596,7 +596,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://socket-firewall.workos.dev/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
@@ -616,7 +616,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
-      "resolved": "https://socket-firewall.workos.dev/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
@@ -632,13 +632,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://socket-firewall.workos.dev/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.7.0",
-      "resolved": "https://socket-firewall.workos.dev/ip-address/-/ip-address-10.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
       "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
@@ -647,7 +647,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://socket-firewall.workos.dev/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
@@ -656,19 +656,19 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://socket-firewall.workos.dev/is-promise/-/is-promise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.12",
-      "resolved": "https://socket-firewall.workos.dev/jose/-/jose-6.2.12.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
       "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
       "license": "MIT",
       "funding": {
@@ -677,19 +677,19 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://socket-firewall.workos.dev/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://socket-firewall.workos.dev/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://socket-firewall.workos.dev/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -698,7 +698,7 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.1",
-      "resolved": "https://socket-firewall.workos.dev/media-typer/-/media-typer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
       "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
@@ -711,7 +711,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
@@ -723,7 +723,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://socket-firewall.workos.dev/mime-db/-/mime-db-1.54.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
@@ -732,7 +732,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://socket-firewall.workos.dev/mime-types/-/mime-types-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
@@ -748,13 +748,13 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://socket-firewall.workos.dev/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.1.0",
-      "resolved": "https://socket-firewall.workos.dev/negotiator/-/negotiator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
       "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
       "license": "MIT",
       "dependencies": {
@@ -770,7 +770,7 @@
     },
     "node_modules/negotiator/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -783,7 +783,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://socket-firewall.workos.dev/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
@@ -792,7 +792,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://socket-firewall.workos.dev/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
@@ -804,7 +804,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://socket-firewall.workos.dev/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
@@ -816,7 +816,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://socket-firewall.workos.dev/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -825,7 +825,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://socket-firewall.workos.dev/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
@@ -834,7 +834,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://socket-firewall.workos.dev/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -843,7 +843,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
-      "resolved": "https://socket-firewall.workos.dev/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
@@ -853,7 +853,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://socket-firewall.workos.dev/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
       "engines": {
@@ -862,7 +862,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://socket-firewall.workos.dev/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
@@ -875,7 +875,7 @@
     },
     "node_modules/qs": {
       "version": "6.16.0",
-      "resolved": "https://socket-firewall.workos.dev/qs/-/qs-6.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
       "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -891,7 +891,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
-      "resolved": "https://socket-firewall.workos.dev/range-parser/-/range-parser-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
@@ -904,7 +904,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://socket-firewall.workos.dev/raw-body/-/raw-body-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
@@ -919,7 +919,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://socket-firewall.workos.dev/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
@@ -928,7 +928,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://socket-firewall.workos.dev/router/-/router-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
@@ -944,13 +944,13 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://socket-firewall.workos.dev/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://socket-firewall.workos.dev/send/-/send-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
@@ -976,7 +976,7 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://socket-firewall.workos.dev/serve-static/-/serve-static-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
@@ -995,13 +995,13 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://socket-firewall.workos.dev/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://socket-firewall.workos.dev/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -1013,7 +1013,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://socket-firewall.workos.dev/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -1022,7 +1022,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
-      "resolved": "https://socket-firewall.workos.dev/side-channel/-/side-channel-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
@@ -1041,7 +1041,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall.workos.dev/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
@@ -1057,7 +1057,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall.workos.dev/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
@@ -1075,7 +1075,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://socket-firewall.workos.dev/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
@@ -1094,7 +1094,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://socket-firewall.workos.dev/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
@@ -1103,7 +1103,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://socket-firewall.workos.dev/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
@@ -1112,7 +1112,7 @@
     },
     "node_modules/type-is": {
       "version": "2.1.0",
-      "resolved": "https://socket-firewall.workos.dev/type-is/-/type-is-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
@@ -1130,7 +1130,7 @@
     },
     "node_modules/type-is/node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://socket-firewall.workos.dev/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -1143,7 +1143,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://socket-firewall.workos.dev/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
@@ -1152,7 +1152,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://socket-firewall.workos.dev/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
@@ -1161,7 +1161,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://socket-firewall.workos.dev/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -1176,13 +1176,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://socket-firewall.workos.dev/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.5.4",
-      "resolved": "https://socket-firewall.workos.dev/zod/-/zod-4.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
       "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
@@ -1191,7 +1191,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
-      "resolved": "https://socket-firewall.workos.dev/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {

--- a/adapters/codex-posthorse/package.json
+++ b/adapters/codex-posthorse/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "codex-posthorse",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Isolated Posthorse context-recovery prototype for Codex.",
+  "license": "MIT",
+  "engines": { "node": ">=22.19.0" },
+  "scripts": {
+    "test": "node --test test/store.test.mjs test/server.test.mjs",
+    "test:runtime": "node --test test/runtime.test.mjs",
+    "test:acceptance": "POSTHORSE_ACCEPTANCE=1 node --test test/runtime.test.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0"
+  }
+}

--- a/adapters/codex-posthorse/scripts/precompact.mjs
+++ b/adapters/codex-posthorse/scripts/precompact.mjs
@@ -1,0 +1,14 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "../store.mjs";
+
+try {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  const stateDir = process.env.POSTHORSE_STATE_DIR ?? join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "posthorse");
+  await createStore(stateDir).checkpoint(JSON.parse(input));
+  process.stdout.write(`${JSON.stringify({ continue: true })}\n`);
+} catch (error) {
+  // Codex continues after a bare nonzero hook exit. A handled failure must explicitly stop it.
+  process.stdout.write(`${JSON.stringify({ continue: false, stopReason: `Posthorse could not save recovery state: ${error.message}` })}\n`);
+}

--- a/adapters/codex-posthorse/scripts/session-start.mjs
+++ b/adapters/codex-posthorse/scripts/session-start.mjs
@@ -1,0 +1,13 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "../store.mjs";
+
+try {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  const stateDir = process.env.POSTHORSE_STATE_DIR ?? join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "posthorse");
+  await createStore(stateDir).register(JSON.parse(input));
+  process.stdout.write(`${JSON.stringify({ continue: true })}\n`);
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({ continue: false, stopReason: `Posthorse could not register this task: ${error.message}` })}\n`);
+}

--- a/adapters/codex-posthorse/server.mjs
+++ b/adapters/codex-posthorse/server.mjs
@@ -1,0 +1,89 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "./store.mjs";
+
+const stateDir = process.env.POSTHORSE_STATE_DIR ?? join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "posthorse");
+const store = createStore(stateDir);
+const server = new Server(
+  { name: "codex-posthorse", version: "0.1.0" },
+  {
+    capabilities: { tools: {} },
+    instructions: "Posthorse stores local task notes and original transcript history. Save current work and outstanding user requests in notes before new_context. After a context reset, read notes and recover details from history; verify live state before continuing actions. Recovery text records inputs, not proof of completed work. Use the threadId from the context-window hint.",
+  },
+);
+
+const properties = {
+  threadId: { type: "string", description: "Current Codex task ID from the context-window hint." },
+  path: { type: "string", description: "Relative note path within this task's notes." },
+  content: { type: "string" },
+  query: { type: "string" },
+  offset: { type: "integer", minimum: 0 },
+  limit: { type: "integer", minimum: 1 },
+};
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "thread_hint",
+      description: "Restore Posthorse task identity, recovery text, and note pointers. Codex calls this automatically for a fresh context window.",
+      inputSchema: { type: "object", properties: { threadId: properties.threadId } },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    {
+      name: "notes",
+      description: "List, read, write, append, or search durable notes for the current task. Read pages use character offsets; list/search pages use entry offsets. Notes do not establish that actions succeeded.",
+      inputSchema: {
+        type: "object",
+        properties: { op: { type: "string", enum: ["list", "read", "write", "append", "search"] }, ...properties },
+        required: ["op", "threadId"],
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
+    },
+    {
+      name: "history",
+      description: "List, search, or read original Codex transcript records, including earlier context windows. Use returned record IDs and next offsets for full recovery. Read records can include stored images.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          op: { type: "string", enum: ["list", "search", "read"] },
+          threadId: properties.threadId,
+          query: properties.query,
+          id: { type: "string" },
+          windowId: { type: "string" },
+          offset: properties.offset,
+          limit: properties.limit,
+        },
+        required: ["op", "threadId"],
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  try {
+    const params = request.params.arguments ?? {};
+    const threadId = request.params._meta?.threadId ?? params.threadId;
+    let result;
+    switch (request.params.name) {
+      case "thread_hint":
+        return { content: [{ type: "text", text: await store.threadHint(threadId) }] };
+      case "notes":
+        result = await store.notes({ ...params, threadId });
+        break;
+      case "history":
+        result = await store.history({ ...params, threadId });
+        break;
+      default:
+        throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+    const { images = [], ...text } = result;
+    return { content: [{ type: "text", text: JSON.stringify(text) }, ...images] };
+  } catch (error) {
+    return { isError: true, content: [{ type: "text", text: error.message }] };
+  }
+});
+
+await server.connect(new StdioServerTransport());

--- a/adapters/codex-posthorse/store.mjs
+++ b/adapters/codex-posthorse/store.mjs
@@ -1,0 +1,396 @@
+import { createReadStream } from "node:fs";
+import { lstat, mkdir, open, readFile, readdir, rename } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
+
+const MAX_HANDOFF_CHARS = 20_000;
+const MAX_RECORD_CHARS = 4_000;
+const TOOL_CALLS = new Set(["function_call", "custom_tool_call", "local_shell_call"]);
+const TOOL_OUTPUTS = new Set(["function_call_output", "custom_tool_call_output", "local_shell_call_output"]);
+
+function required(value, name) {
+	if (typeof value !== "string" || !value.length) throw new Error(`${name} is required.`);
+	return value;
+}
+
+function threadKey(value) {
+	const key = required(value, "threadId");
+	if (key === "." || key === ".." || /[/\\\0]/u.test(key)) throw new Error("threadId must be a single path component.");
+	return key;
+}
+
+function pageParams(params, defaultLimit) {
+	const offset = params.offset ?? 0;
+	const limit = params.limit ?? defaultLimit;
+	if (!Number.isSafeInteger(offset) || offset < 0) throw new Error("offset must be a nonnegative integer.");
+	if (!Number.isSafeInteger(limit) || limit < 1) throw new Error("limit must be a positive integer.");
+	return { offset, limit };
+}
+
+function page(items, params, defaultLimit) {
+	const { offset, limit } = pageParams(params, defaultLimit);
+	const end = Math.min(items.length, offset + limit);
+	return { items: items.slice(offset, end), offset, total: items.length, nextOffset: end < items.length ? end : null };
+}
+
+function textPage(text, params) {
+	const { offset, limit } = pageParams(params, MAX_RECORD_CHARS);
+	const end = Math.min(text.length, offset + limit);
+	return { content: text.slice(offset, end), offset, totalChars: text.length, nextOffset: end < text.length ? end : null };
+}
+
+async function readJson(file) {
+	try {
+		return JSON.parse(await readFile(file, "utf8"));
+	} catch (error) {
+		if (error.code === "ENOENT") return undefined;
+		throw error;
+	}
+}
+
+async function atomicWrite(file, content) {
+	await mkdir(dirname(file), { recursive: true });
+	const temporary = `${file}.${randomUUID()}.tmp`;
+	const handle = await open(temporary, "wx", 0o600);
+	try {
+		await handle.writeFile(content, "utf8");
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+	await rename(temporary, file);
+}
+
+function contentText(value) {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value)) return value.map(contentText).filter(Boolean).join("\n");
+	if (!value || typeof value !== "object") return "";
+	if (typeof value.text === "string") return value.text;
+	if (typeof value.message === "string") return value.message;
+	if (value.type?.includes("image")) return `[${value.type}: recover the original image block with history read]`;
+	if (value.type === "encrypted_content") return "[encrypted content; plaintext unavailable]";
+	return JSON.stringify(value);
+}
+
+function recordText(row) {
+	const payload = row.payload ?? {};
+	if (row.type === "response_item") {
+		if (payload.type === "message" || payload.type === "agent_message") return contentText(payload.content);
+		if (TOOL_CALLS.has(payload.type)) return `${payload.name ?? payload.type}\n${contentText(payload.arguments ?? payload.input ?? payload.action)}`;
+		if (TOOL_OUTPUTS.has(payload.type)) return `${payload.is_error === true || payload.status === "failed" ? "[tool reported failure]\n" : ""}${contentText(payload.output)}`;
+		if (payload.type === "reasoning") return contentText(payload.summary);
+	}
+	if (row.type === "event_msg" && payload.type === "user_message") return contentText(payload.message);
+	if (row.type === "compacted") return payload.message ?? "[context reset]";
+	return JSON.stringify(payload);
+}
+
+async function* transcriptRecords(file) {
+	const stream = createReadStream(file, { encoding: "utf8" });
+	const lines = createInterface({ input: stream, crlfDelay: Infinity });
+	let lineNumber = 0;
+	let windowId = "initial";
+	let turnId;
+	try {
+		for await (const line of lines) {
+			lineNumber++;
+			if (!line.trim()) continue;
+			let row;
+			try {
+				row = JSON.parse(line);
+			} catch {
+				throw new Error(`Transcript contains incomplete or invalid JSON at line ${lineNumber}; checkpoint was not accepted.`);
+			}
+			if (!row || typeof row.type !== "string") throw new Error(`Invalid transcript record at line ${lineNumber}.`);
+			const id = Number.isSafeInteger(row.ordinal) ? `ordinal:${row.ordinal}` : `line:${lineNumber}`;
+			if (row.type === "session_meta") windowId = row.payload?.context_window?.window_id ?? windowId;
+			if (row.type === "compacted") windowId = row.payload?.window_id ?? id;
+			if (row.type === "turn_context" || (row.type === "event_msg" && row.payload?.type === "task_started")) {
+				turnId = row.payload?.turn_id ?? turnId;
+			}
+			yield { id, line: lineNumber, ordinal: row.ordinal, windowId, turnId, timestamp: row.timestamp, row, raw: line };
+		}
+	} finally {
+		lines.close();
+		stream.destroy();
+	}
+}
+
+function metadata(record) {
+	return {
+		id: record.id, line: record.line, ordinal: record.ordinal, windowId: record.windowId,
+		turnId: record.turnId, timestamp: record.timestamp, type: record.row.type,
+		itemType: record.row.payload?.type, role: record.row.payload?.role,
+		callId: record.row.payload?.call_id,
+	};
+}
+
+function imageBlocks(value) {
+	if (Array.isArray(value)) return value.flatMap(imageBlocks);
+	if (!value || typeof value !== "object") return [];
+	if (value.type === "image" && typeof value.data === "string" && typeof value.mimeType === "string") {
+		return [{ type: "image", data: value.data, mimeType: value.mimeType }];
+	}
+	if (value.type === "input_image" || value.type === "image_url") {
+		const url = typeof value.image_url === "string" ? value.image_url : value.image_url?.url;
+		const match = typeof url === "string" && /^data:(image\/[^;,]+);base64,([\s\S]*)$/u.exec(url);
+		return match ? [{ type: "image", mimeType: match[1], data: match[2] }] : [];
+	}
+	return Object.values(value).flatMap(imageBlocks);
+}
+
+function isContextOnly(record) {
+	const content = record.row.payload?.content;
+	const kinds = record.row.payload?.internal_chat_message_metadata_passthrough?.content_item_kinds;
+	if (Array.isArray(kinds) && kinds.length) return !kinds.some((kind) => kind.startsWith("user."));
+	return Array.isArray(content) && content.length > 0 && content.every((block) =>
+		typeof block.text === "string" && /^(?:# AGENTS\.md instructions|<environment_context>|<INSTRUCTIONS>|<permissions instructions>)/u.test(block.text));
+}
+
+function ownerLabel(record) {
+	const kinds = record.row.payload?.internal_chat_message_metadata_passthrough?.content_item_kinds;
+	return record.row.type === "event_msg" || kinds?.some((kind) => kind.startsWith("user."))
+		? "direct user input" : "original user-role input";
+}
+
+function excerpt(text, limit) {
+	if (text.length <= limit) return text;
+	const marker = "\n… omitted; use history read for the original …\n";
+	if (limit <= marker.length) return text.slice(0, limit);
+	const half = Math.floor((limit - marker.length) / 2);
+	return `${text.slice(0, half)}${marker}${text.slice(text.length - (limit - marker.length - half))}`;
+}
+
+async function recoveryFrom(file, threadId, rootThreadId) {
+	const ownerEvents = [];
+	const userItems = [];
+	let calls = new Map();
+	let outputs = [];
+	let responseEnded = false;
+	let last;
+	let sessionId;
+	let boundary;
+	for await (const record of transcriptRecords(file)) {
+		last = record;
+		const { row } = record;
+		const payload = row.payload ?? {};
+		if (row.type === "session_meta") sessionId = payload.id ?? payload.session_id;
+		if (row.type === "compacted") {
+			boundary = record;
+			calls = new Map();
+			outputs = [];
+			responseEnded = false;
+		}
+		if (row.type === "event_msg" && payload.type === "user_message") ownerEvents.push(record);
+		if (row.type === "event_msg" && payload.type === "token_count") responseEnded = true;
+		if (row.type !== "response_item") continue;
+		if (payload.type === "message" && payload.role === "user") userItems.push(record);
+		const assistantOutput = TOOL_CALLS.has(payload.type) || (payload.type === "message" && payload.role === "assistant");
+		if (assistantOutput && payload.status !== "failed" && payload.status !== "incomplete") {
+			if (responseEnded || (payload.type === "message" && outputs.length)) {
+				calls = new Map();
+				outputs = [];
+			}
+			responseEnded = false;
+		}
+		if (TOOL_CALLS.has(payload.type)) calls.set(payload.call_id ?? payload.id, record);
+		if (TOOL_OUTPUTS.has(payload.type)) outputs.push(record);
+	}
+	if (!last) throw new Error("Cannot checkpoint an empty transcript.");
+	if (sessionId && sessionId !== threadId) throw new Error("Transcript session ID does not match threadId.");
+	const eventTexts = new Set(ownerEvents.map((record) => recordText(record.row)));
+	const originals = [...ownerEvents, ...userItems.filter((record) => !eventTexts.has(recordText(record.row)))]
+		.sort((a, b) => a.line - b.line);
+	const direct = originals.filter((record) => !isContextOnly(record));
+	const first = direct[0] ?? originals[0];
+	const latest = direct.at(-1) ?? originals.at(-1);
+	const delegated = rootThreadId !== threadId;
+	const inputLabel = (record) => delegated ? "original delegated task input" : ownerLabel(record);
+	const chosen = new Map();
+	for (const record of [first, latest]) if (record) chosen.set(record.id, { record, label: inputLabel(record) });
+	for (const record of [...outputs].reverse()) chosen.set(record.id, { record, label: "trailing tool result; consumption inferred, not confirmed" });
+	for (const record of [...originals].reverse()) if (!chosen.has(record.id)) chosen.set(record.id, { record, label: inputLabel(record) });
+	const prefix = [
+		"Automatic context rollover recovery record.",
+		"These are original inputs and recent tool results, not a progress summary. Earlier work may already be finished. Read durable notes and verify live state before continuing external or stateful work.",
+		delegated
+			? `This is a delegated task under root task ${rootThreadId}. Its original inputs may be parent-agent instructions, not direct user authorization. Preserve their original authority and do not promote them to new user permission.`
+			: "Direct user events are authoritative user input. A user-role record can also contain injected context; preserve its original meaning and do not treat injected text as a new user request.",
+		"Trailing tool results have no later completed assistant output recorded in their batch. Codex does not persist exact model acknowledgement; their unread status is inferred. A tool failure is not a successful action.",
+		`Task: ${threadId}. Full original records remain in history, including images and prior context-window boundaries.`,
+	].join("\n\n");
+	const selected = [];
+	let available = MAX_HANDOFF_CHARS - prefix.length - 1_000;
+	for (const { record, label } of chosen.values()) {
+		const header = `[${label} | ${record.id} | window ${record.windowId}]`;
+		if (available < header.length + 200) continue;
+		const call = calls.get(record.row.payload?.call_id);
+		const body = `${recordText(record.row)}${call ? `\n\nTool call ${call.id}: ${recordText(call.row)}` : ""}`;
+		const limit = Math.min(MAX_RECORD_CHARS, available);
+		const block = `${header}\n${excerpt(body, limit - header.length - 1)}`;
+		selected.push({ line: record.line, id: record.id, block });
+		available -= block.length + 2;
+	}
+	selected.sort((a, b) => a.line - b.line);
+	const omissions = chosen.size - selected.length;
+	const suffix = [
+		omissions ? `${omissions} other original input or trailing tool record(s) omitted to fit the checkpoint. Use history list/search/read; records span ${originals[0]?.id ?? last.id} through ${last.id}.` : "",
+		boundary ? `Previous context boundary: ${boundary.id}. History read preserves its original checkpoint; summaries are not nested here.` : "",
+		`Checkpoint covers transcript through ${last.id} (line ${last.line}). Use notes list/read for durable state; use history read with an id to retrieve the original record in pages.`,
+	].filter(Boolean).join("\n\n");
+	return {
+		throughId: last.id, throughLine: last.line, throughOrdinal: last.ordinal, windowId: last.windowId,
+		recovery: [prefix, ...selected.map((item) => item.block), suffix].join("\n\n"),
+	};
+}
+
+async function noteFile(root, notePath) {
+	required(notePath, "path");
+	const file = resolve(root, notePath);
+	const subpath = relative(root, file);
+	if (isAbsolute(notePath) || !subpath || subpath === ".." || subpath.startsWith(`..${sep}`) || isAbsolute(subpath) || notePath.includes("\0")) {
+		throw new Error("Note path must stay inside this task's notes directory.");
+	}
+	let candidate = root;
+	for (const part of ["", ...subpath.split(sep)]) {
+		candidate = join(candidate, part);
+		try {
+			if ((await lstat(candidate)).isSymbolicLink()) throw new Error("Note paths cannot follow symbolic links.");
+		} catch (error) {
+			if (error.code !== "ENOENT") throw error;
+		}
+	}
+	return file;
+}
+
+async function notePaths(root, prefix = "") {
+	let entries;
+	try {
+		entries = await readdir(join(root, prefix), { withFileTypes: true });
+	} catch (error) {
+		if (error.code === "ENOENT") return [];
+		throw error;
+	}
+	const result = [];
+	for (const entry of entries) {
+		const name = join(prefix, entry.name);
+		if (entry.isDirectory()) result.push(...await notePaths(root, name));
+		else if (entry.isFile()) result.push(name);
+	}
+	return result.sort();
+}
+
+export function createStore(stateDir) {
+	const root = resolve(required(stateDir, "stateDir"));
+	const manifestPath = (threadId) => join(root, "threads", `${threadKey(threadId)}.json`);
+	const notesRoot = (threadId) => join(root, "notes", threadKey(threadId));
+	async function register(input) {
+		const threadId = threadKey(input.agent_id ?? input.session_id ?? input.threadId);
+		const rootThreadId = input.session_id ?? threadId;
+		const transcriptPath = resolve(required(input.transcript_path ?? input.transcriptPath, "transcript_path"));
+		const prior = await readJson(manifestPath(threadId));
+		const manifest = { ...prior, version: 1, threadId, rootThreadId, transcriptPath };
+		await atomicWrite(manifestPath(threadId), JSON.stringify(manifest, null, 2));
+		return manifest;
+	}
+	async function checkpoint(input) {
+		const threadId = threadKey(input.agent_id ?? input.session_id ?? input.threadId);
+		const rootThreadId = input.session_id ?? threadId;
+		const transcriptPath = resolve(required(input.transcript_path ?? input.transcriptPath, "transcript_path"));
+		const recovery = await recoveryFrom(transcriptPath, threadId, rootThreadId);
+		const checkpoint = {
+			version: 1, id: randomUUID(), threadId, rootThreadId, transcriptPath, turnId: input.turn_id,
+			trigger: input.trigger, createdAt: new Date().toISOString(), ...recovery,
+		};
+		const checkpointPath = join(root, "checkpoints", threadId, `${checkpoint.id}.json`);
+		await atomicWrite(checkpointPath, JSON.stringify(checkpoint, null, 2));
+		await atomicWrite(manifestPath(threadId), JSON.stringify({ version: 1, threadId, rootThreadId, transcriptPath, checkpointPath }, null, 2));
+		return checkpoint;
+	}
+	async function threadHint(threadId) {
+		threadKey(threadId);
+		const manifest = await readJson(manifestPath(threadId));
+		const checkpoint = manifest?.checkpointPath ? await readJson(manifest.checkpointPath) : undefined;
+		if (manifest?.checkpointPath && !checkpoint) throw new Error("Saved checkpoint is missing; recovery cannot be confirmed.");
+		return [
+			checkpoint?.recovery,
+			`Posthorse task ID: ${threadId}. Pass threadId: ${JSON.stringify(threadId)} to notes and history tools.`,
+			"Keep durable decisions, current work, verification, and outstanding user requests in notes. Use notes with op list/read/write/append/search and a relative path. Use history with op list/search/read; copy a record id from list/search, then read it with offset/limit pages. Original image blocks remain in history records. Context boundaries are labeled by windowId. Save current notes before automatic rollover.",
+		].filter(Boolean).join("\n\n");
+	}
+	async function notes(params) {
+		const root = notesRoot(params.threadId);
+		const op = params.op ?? "list";
+		if (op === "list") return page(await notePaths(root), params, 50);
+		if (op === "search") {
+			const query = required(params.query, "query").toLowerCase();
+			const matches = [];
+			for (const path of await notePaths(root)) {
+				const text = await readFile(await noteFile(root, path), "utf8");
+				let index = text.toLowerCase().indexOf(query);
+				while (index >= 0) {
+					matches.push({ path, offset: index, excerpt: text.slice(Math.max(0, index - 100), index + query.length + 200) });
+					index = text.toLowerCase().indexOf(query, index + query.length);
+				}
+			}
+			return page(matches, params, 20);
+		}
+		const file = await noteFile(root, params.path);
+		if (op === "read") return { path: params.path, ...textPage(await readFile(file, "utf8"), params) };
+		if (op !== "write" && op !== "append") throw new Error(`Unsupported notes op: ${op}`);
+		if (typeof params.content !== "string") throw new Error("content must be a string.");
+		let content = params.content;
+		if (op === "append") {
+			required(content, "content");
+			await mkdir(dirname(file), { recursive: true });
+			const handle = await open(file, "a+", 0o600);
+			try {
+				const { size } = await handle.stat();
+				const tail = Buffer.alloc(1);
+				if (size) await handle.read(tail, 0, 1, size - 1);
+				const separator = size && tail[0] !== 10 ? "\n" : "";
+				content = `${separator}${content.endsWith("\n") ? content : `${content}\n`}`;
+				const buffer = Buffer.from(content, "utf8");
+				// One O_APPEND write keeps concurrent newline-terminated records together.
+				const { bytesWritten } = await handle.write(buffer, 0, buffer.length, null);
+				if (bytesWritten !== buffer.length) throw new Error("Note append was incomplete; inspect the note before retrying.");
+				await handle.sync();
+			} finally {
+				await handle.close();
+			}
+			return { path: params.path, writtenChars: content.length };
+		}
+		await atomicWrite(file, content);
+		return { path: params.path, writtenChars: params.content.length, totalChars: content.length };
+	}
+	async function history(params) {
+		const manifest = await readJson(manifestPath(params.threadId));
+		if (!manifest?.transcriptPath) throw new Error("No transcript registered for this task; the SessionStart hook must register it first.");
+		const op = params.op ?? "list";
+		if (!["list", "search", "read"].includes(op)) throw new Error(`Unsupported history op: ${op}`);
+		const query = op === "search" ? required(params.query, "query").toLowerCase() : undefined;
+		if (op === "read") required(params.id, "id");
+		const { offset, limit } = pageParams(params, op === "read" ? MAX_RECORD_CHARS : 20);
+		const items = [];
+		let total = 0;
+		for await (const record of transcriptRecords(manifest.transcriptPath)) {
+			if (params.windowId && record.windowId !== params.windowId) continue;
+			if (op === "read") {
+				if (record.id === params.id) return {
+					...metadata(record), format: "original JSONL record", ...textPage(record.raw, params),
+					images: offset === 0 ? imageBlocks(record.row.payload) : [],
+				};
+				continue;
+			}
+			const text = recordText(record.row);
+			const index = query === undefined ? 0 : text.toLowerCase().indexOf(query);
+			if (index < 0) continue;
+			if (total >= offset && items.length < limit) items.push({ ...metadata(record), excerpt: text.slice(Math.max(0, index - 100), index + 400) });
+			total++;
+		}
+		if (op === "read") throw new Error(`History record not found: ${params.id}`);
+		return { items, offset, total, nextOffset: offset + items.length < total ? offset + items.length : null };
+	}
+	return { register, checkpoint, threadHint, notes, history };
+}

--- a/adapters/codex-posthorse/test/runtime-harness.mjs
+++ b/adapters/codex-posthorse/test/runtime-harness.mjs
@@ -80,16 +80,15 @@ export class RuntimeHarness {
 				if (req.url !== "/v1/responses") throw new Error(`Unexpected model endpoint: ${req.url}`);
 				const reply = this.replies.shift();
 				if (!reply) throw new Error("Unexpected model request: no controlled reply remains");
-				const chosen = typeof reply === "function" ? await reply(request) : reply;
 				const id = `fixture-response-${this.requests.length}`;
 				const events = [
 					{ type: "response.created", response: { id } },
-					...(chosen.items ?? [message("fixture complete")]).map((item, index) => ({
+					...(reply.items ?? [message("fixture complete")]).map((item, index) => ({
 						type: "response.output_item.done", item: { id: `${id}-item-${index}`, ...item },
 					})),
 					{ type: "response.completed", response: { id, usage: {
-						input_tokens: chosen.tokens ?? 100, input_tokens_details: null,
-						output_tokens: 0, output_tokens_details: null, total_tokens: chosen.tokens ?? 100,
+						input_tokens: reply.tokens ?? 100, input_tokens_details: null,
+						output_tokens: 0, output_tokens_details: null, total_tokens: reply.tokens ?? 100,
 					} } },
 				];
 				res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" });

--- a/adapters/codex-posthorse/test/runtime-harness.mjs
+++ b/adapters/codex-posthorse/test/runtime-harness.mjs
@@ -1,0 +1,274 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { createInterface } from "node:readline";
+import { mkdir, mkdtemp, readFile, writeFile, appendFile, rename } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { once } from "node:events";
+
+const adapter = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const timeoutMs = 30_000;
+const quote = (value) => JSON.stringify(value);
+const shellQuote = (value) => `'${value.replaceAll("'", "'\\''")}'`;
+
+export const message = (text) => ({
+	type: "message", role: "assistant", content: [{ type: "output_text", text }],
+});
+
+export const call = (name, args, callId = name, namespace) => ({
+	type: "function_call", name, call_id: callId, arguments: JSON.stringify(args), ...(namespace ? { namespace } : {}),
+});
+
+export const discoverNotes = () => ({
+	type: "tool_search_call", call_id: "discover-notes", execution: "client",
+	arguments: { query: "notes thread notes history", limit: 3 },
+});
+
+export const requestText = (request) => JSON.stringify(request.body.input);
+
+export function contextWindow(request) {
+	return requestText(request).match(/Current context window id: ([0-9a-f-]+)/)?.[1];
+}
+
+export class RuntimeHarness {
+	static async create(name, { tokenBudget = true, failCheckpoint = false } = {}) {
+		const cache = join(homedir(), "Library", "Caches", "pi-runs");
+		await mkdir(cache, { recursive: true });
+		const root = await mkdtemp(join(cache, `posthorse-codex-${name}-`));
+		const harness = new RuntimeHarness(root);
+		harness.tokenBudget = tokenBudget;
+		harness.failCheckpoint = failCheckpoint;
+		try {
+			await harness.initialize();
+			return harness;
+		} catch (error) {
+			await harness.close();
+			throw error;
+		}
+	}
+
+	constructor(root) {
+		this.root = root;
+		this.home = join(root, "codex-home");
+		this.cwd = join(root, "workspace");
+		this.state = join(root, "posthorse");
+		this.requests = [];
+		this.events = [];
+		this.replies = [];
+		this.pending = new Map();
+		this.waiters = new Set();
+		this.sequence = 0;
+		this.launches = 0;
+		this.logWrites = Promise.resolve();
+	}
+
+	async initialize() {
+		await Promise.all([mkdir(this.home), mkdir(this.cwd)]);
+		this.server = createServer(async (req, res) => {
+			try {
+				const chunks = [];
+				for await (const chunk of req) chunks.push(chunk);
+				const raw = Buffer.concat(chunks).toString();
+				const request = { path: req.url, body: raw ? JSON.parse(raw) : null };
+				this.requests.push(request);
+				await appendFile(join(this.root, "model-requests.jsonl"), `${JSON.stringify(request)}\n`);
+				if (this.failCheckpoint && this.requests.length === 1) {
+					await rename(this.state, `${this.state}-before-failure`);
+					await writeFile(this.state, "Deliberately blocks checkpoint-directory creation after SessionStart.\n");
+				}
+				if (req.url !== "/v1/responses") throw new Error(`Unexpected model endpoint: ${req.url}`);
+				const reply = this.replies.shift();
+				if (!reply) throw new Error("Unexpected model request: no controlled reply remains");
+				const chosen = typeof reply === "function" ? await reply(request) : reply;
+				const id = `fixture-response-${this.requests.length}`;
+				const events = [
+					{ type: "response.created", response: { id } },
+					...(chosen.items ?? [message("fixture complete")]).map((item, index) => ({
+						type: "response.output_item.done", item: { id: `${id}-item-${index}`, ...item },
+					})),
+					{ type: "response.completed", response: { id, usage: {
+						input_tokens: chosen.tokens ?? 100, input_tokens_details: null,
+						output_tokens: 0, output_tokens_details: null, total_tokens: chosen.tokens ?? 100,
+					} } },
+				];
+				res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" });
+				for (const event of events) res.write(`data: ${JSON.stringify(event)}\n\n`);
+				res.end();
+			} catch (error) {
+				this.providerError = error;
+				res.writeHead(500, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ error: { message: error.message, type: "fixture_error" } }));
+			}
+		});
+		this.server.listen(0, "127.0.0.1");
+		await once(this.server, "listening");
+		const hookCommand = `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "precompact.mjs"))}`;
+		const sessionCommand = `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "session-start.mjs"))}`;
+		this.config = [
+			'model = "gpt-6-astra"', 'model_provider = "posthorse_fixture"',
+			'model_context_window = 50000', 'model_auto_compact_token_limit = 9000',
+			'approval_policy = "never"', 'sandbox_mode = "danger-full-access"',
+			'web_search = "disabled"',
+			'[features]', 'context_management = false', 'apps = false', 'remote_plugin = false',
+			'memories = false', 'multi_agent = false', 'shell_snapshot = false', 'hooks = true',
+			'code_mode_host = false',
+			'[features.token_budget]', `enabled = ${this.tokenBudget}`, 'use_history_notes_extension = false',
+			'guidance_message = "Use the local notes and history tools to recover durable Posthorse state."',
+			'[model_providers.posthorse_fixture]', 'name = "Posthorse local test"',
+			`base_url = "http://127.0.0.1:${this.server.address().port}/v1"`,
+			'wire_api = "responses"', 'requires_openai_auth = false', 'supports_websockets = false',
+			'request_max_retries = 0', 'stream_max_retries = 0',
+			'[mcp_servers.notes]', `command = ${quote(process.execPath)}`,
+			`args = [${quote(join(adapter, "server.mjs"))}]`,
+			'[mcp_servers.notes.env]', `POSTHORSE_STATE_DIR = ${quote(this.state)}`,
+			'[[hooks.PreCompact]]',
+			'[[hooks.PreCompact.hooks]]', 'type = "command"', `command = ${quote(hookCommand)}`,
+			'[[hooks.SessionStart]]',
+			'[[hooks.SessionStart.hooks]]', 'type = "command"', `command = ${quote(sessionCommand)}`,
+			`[projects.${quote(this.cwd)}]`, 'trust_level = "trusted"',
+		].join("\n") + "\n";
+		await writeFile(join(this.home, "config.toml"), this.config);
+		await this.start();
+		const listed = await this.rpc("hooks/list", { cwds: [this.cwd] });
+		await writeFile(join(this.root, "hooks-list.json"), JSON.stringify(listed, null, 2));
+		const hooks = listed.data.flatMap((entry) => entry.hooks ?? []);
+		if (!hooks.length) throw new Error(`No hooks discovered: ${JSON.stringify(listed)}`);
+		await this.stop();
+		for (const hook of hooks) this.config += `\n[hooks.state.${quote(hook.key)}]\ntrusted_hash = ${quote(hook.currentHash)}\n`;
+		await writeFile(join(this.home, "config.toml"), this.config);
+		await this.start();
+	}
+
+	async start() {
+		this.launches++;
+		this.child = spawn(process.env.POSTHORSE_CODEX_BIN ?? "codex", ["app-server", "--stdio", "--strict-config"], {
+			cwd: this.cwd,
+			env: {
+				PATH: process.env.PATH, HOME: homedir(), TMPDIR: process.env.TMPDIR,
+				CODEX_HOME: this.home, POSTHORSE_STATE_DIR: this.state, NO_COLOR: "1",
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		this.child.stderr.on("data", (chunk) => {
+			this.logWrites = this.logWrites.then(() => appendFile(join(this.root, `runtime-${this.launches}.stderr.log`), chunk));
+		});
+		this.child.on("error", (error) => this.rejectPending(error));
+		this.child.on("exit", (code, signal) => this.rejectPending(new Error(`Codex exited (${code ?? signal}); artifacts: ${this.root}`)));
+		this.lines = createInterface({ input: this.child.stdout });
+		this.lines.on("line", (line) => {
+			this.logWrites = this.logWrites.then(() => appendFile(join(this.root, "app-server.jsonl"), `${line}\n`));
+			let event;
+			try { event = JSON.parse(line); }
+			catch {
+				this.protocolError = new Error(`Codex emitted invalid JSON; artifacts: ${this.root}`);
+				this.rejectPending(this.protocolError);
+				return;
+			}
+			if (event.id !== undefined && !event.method) {
+				const pending = this.pending.get(event.id);
+				if (pending) {
+					this.pending.delete(event.id);
+					clearTimeout(pending.timer);
+					if (event.error) pending.reject(new Error(JSON.stringify(event.error)));
+					else pending.resolve(event.result);
+				}
+			} else {
+				this.events.push(event);
+				for (const waiter of [...this.waiters]) if (waiter.predicate(event)) {
+					clearTimeout(waiter.timer);
+					this.waiters.delete(waiter);
+					waiter.resolve(event);
+				}
+			}
+		});
+		await this.rpc("initialize", { clientInfo: { name: "posthorse-runtime-test", version: "0.1.0" }, capabilities: { experimentalApi: true } });
+		this.child.stdin.write(`${JSON.stringify({ method: "initialized", params: {} })}\n`);
+	}
+
+	rejectPending(error) {
+		for (const pending of this.pending.values()) { clearTimeout(pending.timer); pending.reject(error); }
+		this.pending.clear();
+		for (const waiter of this.waiters) { clearTimeout(waiter.timer); waiter.reject(error); }
+		this.waiters.clear();
+	}
+
+	rpc(method, params) {
+		if (this.protocolError) return Promise.reject(this.protocolError);
+		const id = ++this.sequence;
+		return new Promise((resolveResult, reject) => {
+			const timer = setTimeout(() => { this.pending.delete(id); reject(new Error(`Timed out: ${method}; artifacts: ${this.root}`)); }, timeoutMs);
+			this.pending.set(id, { resolve: resolveResult, reject, timer });
+			this.child.stdin.write(`${JSON.stringify({ id, method, params })}\n`);
+		});
+	}
+
+	waitFor(predicate, from = 0) {
+		if (this.protocolError) return Promise.reject(this.protocolError);
+		const found = this.events.slice(from).find(predicate);
+		if (found) return Promise.resolve(found);
+		return new Promise((resolveResult, reject) => {
+			const waiter = { predicate, resolve: resolveResult, reject };
+			waiter.timer = setTimeout(() => { this.waiters.delete(waiter); reject(new Error(`Timed out waiting for runtime event; artifacts: ${this.root}`)); }, timeoutMs);
+			this.waiters.add(waiter);
+		});
+	}
+
+	async thread() {
+		const result = await this.rpc("thread/start", {
+			cwd: this.cwd, model: "gpt-6-astra", modelProvider: "posthorse_fixture",
+			approvalPolicy: "never", sandbox: "danger-full-access",
+			baseInstructions: "You are a controlled local integration fixture. Follow the exact tool sequence supplied by the fixture provider.",
+		});
+		this.threadId = result.thread.id;
+		this.transcript = result.thread.path;
+		return result;
+	}
+
+	async turn(text, replies) {
+		this.replies.push(...replies);
+		const from = this.events.length;
+		const result = await this.rpc("turn/start", { threadId: this.threadId, input: [{ type: "text", text }] });
+		const completed = await this.waitFor((event) => event.method === "turn/completed" && event.params.turn.id === result.turn.id, from);
+		if (this.providerError) throw this.providerError;
+		return completed.params.turn;
+	}
+
+	async compact(replies = []) {
+		this.replies.push(...replies);
+		const from = this.events.length;
+		await this.rpc("thread/compact/start", { threadId: this.threadId });
+		await this.waitFor((event) => event.method === "turn/completed", from);
+		if (this.providerError) throw this.providerError;
+	}
+
+	async restart() {
+		await this.stop();
+		await this.start();
+		await this.rpc("thread/resume", { threadId: this.threadId, cwd: this.cwd });
+	}
+
+	async transcriptItems() {
+		const thread = await this.rpc("thread/read", { threadId: this.threadId, includeTurns: false });
+		this.transcript = thread.thread.path;
+		return (await readFile(this.transcript, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+	}
+
+	async stop() {
+		if (!this.child?.pid || this.child.exitCode !== null) return;
+		const child = this.child;
+		const stopped = once(child, "exit");
+		child.stdin.end();
+		const timer = setTimeout(() => child.kill("SIGTERM"), 1500);
+		await stopped;
+		clearTimeout(timer);
+		this.lines?.close();
+		await this.logWrites;
+	}
+
+	async close() {
+		await this.stop();
+		if (this.server?.listening) await new Promise((resolveClosed) => this.server.close(resolveClosed));
+		await this.logWrites;
+	}
+}

--- a/adapters/codex-posthorse/test/runtime.test.mjs
+++ b/adapters/codex-posthorse/test/runtime.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { RuntimeHarness, call, message, contextWindow, requestText, discoverNotes } from "./runtime-harness.mjs";
+
+const acceptance = process.env.POSTHORSE_ACCEPTANCE === "1";
+const ownerRequest = "OWNER_REQUEST_47: preserve this instruction and finish the recovery proof.";
+const unreadResult = "UNREAD_TOOL_RESULT_83";
+const failedResult = "FAILED_SIBLING_RESULT_59";
+
+async function usingRuntime(t, name, options, run) {
+	const h = await RuntimeHarness.create(name, options);
+	t.diagnostic(`Retained real-runtime artifacts: ${h.root}`);
+	try { await h.thread(); await run(h); }
+	finally { await h.close(); }
+}
+
+async function recordAcceptance(t, h, name, passed, detail) {
+	await writeFile(join(h.root, "acceptance.json"), JSON.stringify({
+		name, passed, detail, runtime: process.env.POSTHORSE_CODEX_BIN ?? "codex",
+		threadId: h.threadId, transcript: h.transcript,
+	}, null, 2) + "\n");
+	if (!passed) t.diagnostic(`UNMET ACCEPTANCE: ${detail}`);
+	if (acceptance) assert.ok(passed, detail);
+}
+
+test("automatic rollover restores user instructions and unread output through the real notes bridge, then survives restart", async (t) => {
+	await usingRuntime(t, "auto-restart", {}, async (h) => {
+		const turn = await h.turn(ownerRequest, [
+			{ items: [call("exec_command", { cmd: `printf '${unreadResult}\\n'`, login: false }, "unread-result")], tokens: 9_500 },
+			{ items: [message("automatic rollover finished")] },
+		]);
+		assert.equal(turn.status, "completed");
+		assert.equal(h.requests.length, 2);
+		assert.ok(h.events.some((event) => event.method === "mcpServer/startupStatus/updated" && event.params.name === "notes" && event.params.status === "ready"), "real notes MCP must be connected");
+		const firstWindow = contextWindow(h.requests[0]);
+		const nextWindow = contextWindow(h.requests[1]);
+		assert.ok(firstWindow && nextWindow);
+		assert.notEqual(nextWindow, firstWindow, "native rollover must actually occur");
+		assert.match(requestText(h.requests[1]), /OWNER_REQUEST_47/);
+		assert.match(requestText(h.requests[1]), /UNREAD_TOOL_RESULT_83/);
+		assert.ok(!h.requests[1].body.input.some((item) => item.type === "function_call_output" && item.call_id === "unread-result"), "recovery must arrive in notes, not retained active tool history");
+		const transcript = await h.transcriptItems();
+		assert.ok(transcript.some((entry) => entry.type === "compacted"), "rollover checkpoint must be persisted");
+		assert.ok(JSON.stringify(transcript).includes(unreadResult), "original tool output remains in full history");
+		const originalOutput = transcript.find((entry) => entry.type === "response_item" && entry.payload.type === "function_call_output" && entry.payload.call_id === "unread-result");
+		await h.turn("Save the durable handoff note.", [
+			{ items: [discoverNotes()] },
+			{ items: [call("notes", { op: "write", threadId: h.threadId, path: "handoff.md", content: "DURABLE_NOTE_14: continue the existing recovery proof." }, "write-note", "mcp__notes")] },
+			{ items: [message("durable note saved")] },
+		]);
+		assert.match(JSON.stringify(h.requests.at(-1).body.input.find((item) => item.call_id === "write-note" && item.type === "function_call_output")), /writtenChars/);
+		await h.restart();
+		await h.turn("Continue the same task after restarting the runtime.", [
+			{ items: [discoverNotes()] },
+			{ items: [
+				call("notes", { op: "read", threadId: h.threadId, path: "handoff.md" }, "read-note", "mcp__notes"),
+				call("history", { op: "read", threadId: h.threadId, id: `ordinal:${originalOutput.ordinal}` }, "read-original-output", "mcp__notes"),
+			] },
+			{ items: [message("restart recovery finished")] },
+		]);
+		const resumed = h.requests.at(-1);
+		assert.match(requestText(resumed), /OWNER_REQUEST_47/);
+		assert.match(requestText(resumed), /UNREAD_TOOL_RESULT_83/);
+		assert.match(JSON.stringify(resumed.body.input.find((item) => item.call_id === "read-note" && item.type === "function_call_output")), /DURABLE_NOTE_14/);
+		assert.match(JSON.stringify(resumed.body.input.find((item) => item.call_id === "read-original-output" && item.type === "function_call_output")), /UNREAD_TOOL_RESULT_83/);
+		assert.equal(contextWindow(resumed), nextWindow);
+		await recordAcceptance(t, h, "automatic-rollover-and-restart", true, "Native rollover and restart preserve original user instructions and unread tool output through local recovery notes.");
+	});
+});
+
+test("a failed checkpoint stops automatic rollover and preserves the original transcript", async (t) => {
+	await usingRuntime(t, "failed-checkpoint", { failCheckpoint: true }, async (h) => {
+		const turn = await h.turn(ownerRequest, [
+			{ items: [call("exec_command", { cmd: `printf '${unreadResult}\\n'`, login: false }, "unread-before-failed-write")], tokens: 9_500 },
+		]);
+		assert.notEqual(turn.status, "completed");
+		assert.equal(h.requests.length, 1, "failed checkpoint must stop before another model request");
+		const transcript = await h.transcriptItems();
+		assert.equal(transcript.filter((entry) => entry.type === "compacted").length, 0);
+		assert.ok(JSON.stringify(transcript).includes(ownerRequest));
+		assert.ok(JSON.stringify(transcript).includes(unreadResult));
+		await recordAcceptance(t, h, "checkpoint-failure", true, "A real filesystem checkpoint failure stops rollover without removing original history.");
+	});
+});
+
+test("manual compaction: compare ordinary summary behavior with local token-budget mode", async (t) => {
+	let ordinarySummaryRequests;
+	await usingRuntime(t, "manual-ordinary", { tokenBudget: false }, async (h) => {
+		await h.turn(ownerRequest, [{ items: [message("work before manual compaction")] }]);
+		const before = h.requests.length;
+		await h.compact([{ items: [message("MANUAL_SUMMARY_21: preserve the original user request.")] }]);
+		ordinarySummaryRequests = h.requests.length - before;
+		assert.equal(ordinarySummaryRequests, 1, "ordinary manual compaction must use the model summarizer");
+		assert.ok(JSON.stringify(await h.transcriptItems()).includes("MANUAL_SUMMARY_21"));
+	});
+	await usingRuntime(t, "manual-token-budget", {}, async (h) => {
+		await h.turn(ownerRequest, [{ items: [message("work before manual compaction")] }]);
+		const initialWindow = contextWindow(h.requests[0]);
+		const before = h.requests.length;
+		await h.compact([{ items: [message("MANUAL_SUMMARY_21: preserve the original user request.")] }]);
+		const summaryRequests = h.requests.length - before;
+		// Remove a reply that stock token-budget mode never consumes, before inspecting the next turn.
+		if (!summaryRequests) h.replies.shift();
+		await h.turn("Continue after manual compaction.", [{ items: [message("continued")] }]);
+		assert.ok(summaryRequests === ordinarySummaryRequests || contextWindow(h.requests.at(-1)) !== initialWindow, "runtime must either summarize or install a fresh window");
+		await h.transcriptItems();
+		await recordAcceptance(t, h, "manual-summary-parity", summaryRequests === ordinarySummaryRequests,
+			`Manual /compact made ${summaryRequests} summary requests in token-budget mode versus ${ordinarySummaryRequests} normally. Posthorse requires ordinary manual summarization.`);
+	});
+});
+
+test("explicit new_context with a failing command preserves recovery text but must not commit the window", async (t) => {
+	await usingRuntime(t, "explicit-failing-sibling", {}, async (h) => {
+		const turn = await h.turn(ownerRequest, [
+			{ items: [call("new_context", {}, "explicit-rollover"), call("exec_command", {
+				cmd: `printf '${failedResult}\\n' >&2; exit 7`, login: false,
+			}, "failed-sibling")] },
+			{ items: [message("continued after tool batch")] },
+		]);
+		assert.equal(turn.status, "completed");
+		assert.equal(h.requests.length, 2);
+		const transcript = await h.transcriptItems();
+		assert.ok(JSON.stringify(transcript).includes(ownerRequest), "user request remains recoverable in original transcript");
+		assert.ok(JSON.stringify(transcript).includes(failedResult), "failed tool output remains recoverable in original transcript");
+		const continuation = requestText(h.requests[1]);
+		assert.ok(continuation.includes("OWNER_REQUEST_47") && continuation.includes(failedResult), "the local hook must preserve recovery text even if native batch cancellation is unsupported");
+		const unchanged = contextWindow(h.requests[1]) === contextWindow(h.requests[0]);
+		await recordAcceptance(t, h, "explicit-failing-command", unchanged,
+			`A command exited 7 beside new_context. Window unchanged: ${unchanged}. Posthorse must cancel the pending rollover when a sibling fails.`);
+	});
+});
+
+test("explicit new_context with an actual MCP isError sibling records whether the window is canceled", async (t) => {
+	await usingRuntime(t, "explicit-mcp-error", {}, async (h) => {
+		await h.turn(ownerRequest, [
+			{ items: [discoverNotes()] },
+			{ items: [call("new_context", {}, "explicit-rollover"), call("notes", {
+				op: "read", threadId: h.threadId, path: "missing-note-for-error-proof.md",
+			}, "failed-mcp-sibling", "mcp__notes")] },
+			{ items: [message("continued after failed MCP batch")] },
+		]);
+		assert.equal(h.requests.length, 3);
+		const transcript = await h.transcriptItems();
+		const failed = transcript.find((entry) => entry.type === "response_item" && entry.payload.type === "function_call_output" && entry.payload.call_id === "failed-mcp-sibling");
+		assert.ok(failed, "real failing MCP output must be persisted");
+		assert.match(JSON.stringify(failed), /ENOENT/);
+		assert.ok(h.events.some((event) => event.method === "item/completed" && event.params.item.type === "mcpToolCall" && event.params.item.status === "failed"), "Codex must classify the real MCP tool call as failed");
+		const unchanged = contextWindow(h.requests[2]) === contextWindow(h.requests[1]);
+		await recordAcceptance(t, h, "explicit-mcp-error", unchanged,
+			`MCP notes.read returned isError for a missing note beside new_context. Window unchanged: ${unchanged}; persisted compacted records: ${transcript.filter((entry) => entry.type === "compacted").length}.`);
+	});
+});

--- a/adapters/codex-posthorse/test/server.test.mjs
+++ b/adapters/codex-posthorse/test/server.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+
+async function fixture(t) {
+  const cache = join(homedir(), "Library", "Caches", "pi-runs");
+  await mkdir(cache, { recursive: true });
+  const dir = await mkdtemp(join(cache, "posthorse-codex-mcp-"));
+  t.diagnostic(`Retained artifacts: ${dir}`);
+  const sessionId = randomUUID();
+  const transcript = join(dir, "rollout.jsonl");
+  const records = [
+    { ordinal: 0, type: "session_meta", payload: { id: sessionId, cwd: dir } },
+    { ordinal: 1, type: "turn_context", payload: { turn_id: "turn-1", model: "fixture-model" } },
+    { ordinal: 2, type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Keep unique-input in the recovery record." }] } },
+  ];
+  await writeFile(transcript, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  return { dir, sessionId, transcript, stateDir: join(dir, "state") };
+}
+
+async function hook(script, data, stateDir) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(root, "scripts", script)], {
+      env: { ...process.env, POSTHORSE_STATE_DIR: stateDir },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => { stdout += data; });
+    child.stderr.on("data", (data) => { stderr += data; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(JSON.stringify(data));
+  });
+}
+
+test("real MCP server shares task notes, original history, and hook recovery across processes", async (t) => {
+  const f = await fixture(t);
+  const input = { session_id: f.sessionId, transcript_path: f.transcript, turn_id: "turn-1", trigger: "auto" };
+  const registered = await hook("session-start.mjs", { ...input, hook_event_name: "SessionStart" }, f.stateDir);
+  assert.equal(registered.code, 0, registered.stderr);
+  assert.equal(JSON.parse(registered.stdout).continue, true);
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(root, "server.mjs")],
+    env: { ...process.env, POSTHORSE_STATE_DIR: f.stateDir },
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "posthorse-integration-test", version: "1.0.0" });
+  t.after(() => client.close());
+  await client.connect(transport);
+  const tools = await client.listTools();
+  assert.deepEqual(tools.tools.map((tool) => tool.name).sort(), ["history", "notes", "thread_hint"]);
+
+  const written = await client.callTool({ name: "notes", arguments: { op: "write", threadId: f.sessionId, path: "checkpoint.md", content: "Continue the pending verification." } });
+  assert.notEqual(written.isError, true, JSON.stringify(written));
+  const read = await client.callTool({ name: "notes", arguments: { op: "read", threadId: f.sessionId, path: "checkpoint.md" } });
+  assert.match(JSON.stringify(read), /Continue the pending verification/);
+  const history = await client.callTool({ name: "history", arguments: { op: "search", threadId: f.sessionId, query: "unique-input" } });
+  assert.notEqual(history.isError, true, JSON.stringify(history));
+  assert.match(JSON.stringify(history), /unique-input/);
+
+  const checkpointed = await hook("precompact.mjs", { ...input, hook_event_name: "PreCompact" }, f.stateDir);
+  assert.equal(checkpointed.code, 0, checkpointed.stderr);
+  assert.equal(JSON.parse(checkpointed.stdout).continue, true);
+  const hint = await client.callTool({ name: "thread_hint", arguments: {}, _meta: { threadId: f.sessionId } });
+  assert.notEqual(hint.isError, true, JSON.stringify(hint));
+  assert.match(JSON.stringify(hint), /unique-input/);
+  assert.match(JSON.stringify(hint), /notes list\/read/);
+  const recovered = await client.callTool({ name: "notes", arguments: { op: "read", threadId: f.sessionId, path: "checkpoint.md" } });
+  assert.match(JSON.stringify(recovered), /Continue the pending verification/);
+});
+
+test("checkpoint storage failure emits Codex's explicit stop response", async (t) => {
+  const f = await fixture(t);
+  await writeFile(f.stateDir, "not a directory");
+  const result = await hook("precompact.mjs", { session_id: f.sessionId, transcript_path: f.transcript, turn_id: "turn-1", trigger: "auto" }, f.stateDir);
+  assert.equal(result.code, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.continue, false);
+  assert.match(output.stopReason, /could not save recovery state/);
+});

--- a/adapters/codex-posthorse/test/store.test.mjs
+++ b/adapters/codex-posthorse/test/store.test.mjs
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createStore } from "../store.mjs";
+
+const threadId = "test-thread";
+const user = (text, kinds = ["user.text"]) => ({
+	type: "response_item", payload: {
+		type: "message", role: "user", content: [{ type: "input_text", text }],
+		internal_chat_message_metadata_passthrough: { content_item_kinds: kinds },
+	},
+});
+const call = (id, name = "exec_command") => ({
+	type: "response_item", payload: { type: "function_call", call_id: id, name, arguments: '{"cmd":"test command"}' },
+});
+const output = (id, text, extra = {}) => ({
+	type: "response_item", payload: { type: "function_call_output", call_id: id, output: text, ...extra },
+});
+const assistant = (text) => ({
+	type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text }] },
+});
+const tokenCount = { type: "event_msg", payload: { type: "token_count", info: {} } };
+
+async function fixture(records, { ordinals = true, firstWindowId } = {}) {
+	const cache = join(homedir(), "Library", "Caches", "pi-runs");
+	await mkdir(cache, { recursive: true });
+	const dir = await mkdtemp(join(cache, "posthorse-store-test-"));
+	const transcript = join(dir, "rollout.jsonl");
+	const rows = [{ type: "session_meta", payload: { id: threadId, ...(firstWindowId ? { context_window: { window_id: firstWindowId } } : {}) } }, ...records].map((row, index) => ({
+		timestamp: "2026-09-09T12:00:00Z", ...(ordinals ? { ordinal: index } : {}), ...row,
+	}));
+	const original = rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+	await writeFile(transcript, original);
+	const stateDir = join(dir, "state");
+	const store = createStore(stateDir);
+	await store.register({ session_id: threadId, transcript_path: transcript });
+	return { dir, transcript, stateDir, store, original, rows, hook: { session_id: threadId, transcript_path: transcript, trigger: "auto", turn_id: "turn-1" } };
+}
+
+test("checkpoint keeps original requests across reset boundaries without promoting assistant progress", async () => {
+	const f = await fixture([
+		user("<environment_context>injected context</environment_context>", ["environments.environment_context"]),
+		user("ORIGINAL_REQUEST build the approved behavior"),
+		assistant("STALE_ASSISTANT_PROSE everything is done"),
+		{ type: "compacted", payload: { message: "OLD_SUMMARY do something else", replacement_history: [] } },
+		user("LATEST_REQUEST also keep manual compact working"),
+		call("call-1"), output("call-1", "UNREAD_RESULT production check failed", { is_error: true }), tokenCount,
+	]);
+	const checkpoint = await f.store.checkpoint(f.hook);
+	assert.match(checkpoint.recovery, /ORIGINAL_REQUEST/);
+	assert.match(checkpoint.recovery, /LATEST_REQUEST/);
+	assert.match(checkpoint.recovery, /UNREAD_RESULT/);
+	assert.match(checkpoint.recovery, /\[tool reported failure\]/);
+	assert.match(checkpoint.recovery, /Tool call ordinal:6/);
+	assert.match(checkpoint.recovery, /direct user input \| ordinal:2/);
+	assert.doesNotMatch(checkpoint.recovery, /STALE_ASSISTANT_PROSE|OLD_SUMMARY/);
+	assert.match(checkpoint.recovery, /Previous context boundary: ordinal:4/);
+	assert.match(checkpoint.recovery, /acknowledgement.*inferred/);
+	assert.equal(await readFile(f.transcript, "utf8"), f.original);
+	const restarted = createStore(f.stateDir);
+	assert.match(await restarted.threadHint(threadId), /UNREAD_RESULT/);
+	assert.match(await restarted.threadHint(threadId), /threadId: "test-thread"/);
+});
+
+test("interleaved sibling tool results survive but results followed by a new model response do not", async () => {
+	const f = await fixture([
+		user("Check both independent tools"),
+		call("old"), output("old", "ALREADY_CONSUMED"), tokenCount,
+		call("one"), output("one", "FIRST_SIBLING"), call("two"), output("two", "SECOND_SIBLING"), tokenCount,
+	]);
+	const checkpoint = await f.store.checkpoint(f.hook);
+	assert.doesNotMatch(checkpoint.recovery, /ALREADY_CONSUMED/);
+	assert.match(checkpoint.recovery, /FIRST_SIBLING/);
+	assert.match(checkpoint.recovery, /SECOND_SIBLING/);
+	await writeFile(f.transcript, f.original + JSON.stringify({ ...assistant("Consumed all results"), ordinal: 11 }) + "\n");
+	assert.doesNotMatch((await f.store.checkpoint(f.hook)).recovery, /FIRST_SIBLING|SECOND_SIBLING|Consumed all results/);
+});
+
+test("an aborted response with reasoning alone does not acknowledge prior tool results", async () => {
+	const f = await fixture([
+		user("Continue until verified"), call("pending"), output("pending", "KEEP_AFTER_FAILURE"), tokenCount,
+		{ type: "response_item", payload: { type: "reasoning", summary: [{ type: "summary_text", text: "unfinished reasoning" }] } },
+		{ type: "event_msg", payload: { type: "turn_aborted", reason: "interrupted" } },
+	]);
+	assert.match((await f.store.checkpoint(f.hook)).recovery, /KEEP_AFTER_FAILURE/);
+});
+
+test("bounded checkpoints point back to complete paged originals and retain old checkpoints", async () => {
+	const f = await fixture([
+		user("FIRST_REQUEST_" + "a".repeat(12_000)),
+		...Array.from({ length: 20 }, (_, i) => user(`REQUEST_${i}_` + "b".repeat(12_000))),
+		call("tail"), output("tail", "LAST_TOOL_RESULT_" + "c".repeat(12_000)), tokenCount,
+	]);
+	const a = await f.store.checkpoint(f.hook);
+	assert.ok(a.recovery.length <= 20_000);
+	assert.ok((await f.store.threadHint(threadId)).length <= 20_000);
+	assert.match(a.recovery, /FIRST_REQUEST_|omitted; use history/);
+	assert.match(a.recovery, /REQUEST_19_/);
+	assert.match(a.recovery, /LAST_TOOL_RESULT_/);
+	assert.match(a.recovery, /other original input or trailing tool record\(s\) omitted/);
+	let original = "";
+	let offset = 0;
+	do {
+		const page = await f.store.history({ threadId, op: "read", id: "ordinal:1", offset, limit: 997 });
+		original += page.content;
+		offset = page.nextOffset;
+	} while (offset !== null);
+	assert.deepEqual(JSON.parse(original), f.rows[1]);
+	await f.store.checkpoint(f.hook);
+	assert.equal((await readdir(join(f.stateDir, "checkpoints", threadId))).filter((name) => name.endsWith(".json")).length, 2);
+});
+
+test("history pages, searches, window labels, and image records survive restart exactly", async () => {
+	const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aCBkAAAAASUVORK5CYII=";
+	const image = { type: "input_image", image_url: `data:image/png;base64,${png}`, detail: "original" };
+	const imageUser = user("IMAGE_REQUEST");
+	imageUser.payload.content.push(image);
+	const f = await fixture([
+		user("needle before reset"), imageUser,
+		{ type: "compacted", payload: { message: "boundary", window_id: "native-window-1", replacement_history: [] } },
+		user("needle after reset"),
+		{ type: "turn_context", payload: { turn_id: "turn-after", cwd: "/scratch" } },
+	], { firstWindowId: "native-window-0" });
+	const restarted = createStore(f.stateDir);
+	const first = await restarted.history({ threadId, op: "list", limit: 2 });
+	assert.equal(first.items.length, 2);
+	assert.equal(first.nextOffset, 2);
+	const second = await restarted.history({ threadId, op: "list", offset: first.nextOffset, limit: 20 });
+	assert.equal(second.nextOffset, null);
+	assert.equal(first.items.length + second.items.length, f.rows.length);
+	const hit = await restarted.history({ threadId, op: "search", query: "needle", limit: 1 });
+	assert.equal(hit.total, 2);
+	assert.equal(hit.items[0].windowId, "native-window-0");
+	const before = await restarted.history({ threadId, op: "list", windowId: "native-window-0" });
+	assert.deepEqual(before.items.map((item) => item.id), ["ordinal:0", "ordinal:1", "ordinal:2"]);
+	const nextHit = await restarted.history({ threadId, op: "search", query: "needle", offset: hit.nextOffset, limit: 1 });
+	assert.equal(nextHit.items[0].windowId, "native-window-1");
+	const after = await restarted.history({ threadId, op: "list", windowId: "native-window-1" });
+	assert.deepEqual(after.items.map((item) => item.id), ["ordinal:3", "ordinal:4", "ordinal:5"]);
+	const read = await restarted.history({ threadId, op: "read", id: "ordinal:2", limit: 20_000 });
+	assert.deepEqual(JSON.parse(read.content).payload.content[1], image);
+	assert.deepEqual(read.images, [{ type: "image", mimeType: "image/png", data: png }]);
+	assert.deepEqual((await restarted.history({ threadId, op: "read", id: "ordinal:2", offset: 1 })).images, []);
+	const toolImage = { type: "image", mimeType: "image/png", data: png };
+	const row = { ...output("image-result", [toolImage]), ordinal: 6 };
+	await writeFile(f.transcript, f.original + JSON.stringify(row) + "\n");
+	assert.deepEqual((await restarted.history({ threadId, op: "read", id: "ordinal:6" })).images, [toolImage]);
+});
+
+test("legacy direct-user events deduplicate their response copies and support line IDs", async () => {
+	const f = await fixture([
+		{ type: "event_msg", payload: { type: "user_message", message: "DIRECT_EVENT_REQUEST", images: [] } },
+		user("DIRECT_EVENT_REQUEST"),
+	], { ordinals: false });
+	const checkpoint = await f.store.checkpoint(f.hook);
+	assert.equal(checkpoint.recovery.match(/DIRECT_EVENT_REQUEST/g)?.length, 1);
+	assert.match(checkpoint.recovery, /direct user input \| line:2/);
+	const read = await f.store.history({ threadId, op: "read", id: "line:2" });
+	assert.equal(JSON.parse(read.content).payload.message, "DIRECT_EVENT_REQUEST");
+});
+
+test("notes list, exact append, search, and character paging persist independently per task", async () => {
+	const f = await fixture([user("Keep durable notes")]);
+	await f.store.notes({ threadId, op: "write", path: "work/current.md", content: "First needle.\n" });
+	await f.store.notes({ threadId, op: "append", path: "work/current.md", content: "Second needle." });
+	await f.store.notes({ threadId: "another-thread", op: "write", path: "work/current.md", content: "Other task" });
+	const restarted = createStore(f.stateDir);
+	assert.deepEqual((await restarted.notes({ threadId, op: "list" })).items, ["work/current.md"]);
+	const read = await restarted.notes({ threadId, op: "read", path: "work/current.md", limit: 14 });
+	assert.equal(read.content, "First needle.\n");
+	assert.equal((await restarted.notes({ threadId, op: "read", path: "work/current.md", offset: read.nextOffset })).content, "Second needle.\n");
+	const search = await restarted.notes({ threadId, op: "search", query: "needle", limit: 1 });
+	assert.equal(search.total, 2);
+	assert.equal(search.nextOffset, 1);
+	assert.equal((await restarted.notes({ threadId: "another-thread", op: "read", path: "work/current.md" })).content, "Other task");
+	assert.match(await restarted.threadHint("task-without-checkpoint"), /Posthorse task ID: task-without-checkpoint/);
+});
+
+test("parallel note appends preserve complete records through independent store instances", async () => {
+	const f = await fixture([user("Append all worker observations")]);
+	await f.store.notes({ threadId, op: "write", path: "workers.md", content: "Existing unterminated line" });
+	const records = Array.from({ length: 30 }, (_, index) => `Worker ${index}: ${"result ".repeat(500)}`);
+	await Promise.all(records.map((content) => createStore(f.stateDir).notes({ threadId, op: "append", path: "workers.md", content })));
+	const read = await f.store.notes({ threadId, op: "read", path: "workers.md", limit: 200_000 });
+	assert.ok(read.content.endsWith("\n"));
+	assert.deepEqual(new Set(read.content.split("\n").filter(Boolean)), new Set(["Existing unterminated line", ...records]));
+	assert.equal(read.content.split("\n").filter(Boolean).length, records.length + 1);
+});
+
+test("path escape, malformed pages, and missing records fail without hiding errors", async () => {
+	const f = await fixture([user("Keep notes in scope")]);
+	await assert.rejects(f.store.notes({ threadId: "../other", op: "write", path: "x", content: "x" }), /single path component/);
+	for (const path of ["../escape.md", "/tmp/escape.md", "nested/../../escape.md", "."]) {
+		await assert.rejects(f.store.notes({ threadId, op: "write", path, content: "escape" }), /inside this task/);
+	}
+	await f.store.notes({ threadId, op: "write", path: "safe.md", content: "safe" });
+	await symlink(f.dir, join(f.stateDir, "notes", threadId, "link"));
+	await assert.rejects(f.store.notes({ threadId, op: "write", path: "link/escape.md", content: "escape" }), /symbolic links/);
+	await assert.rejects(f.store.history({ threadId, op: "list", offset: -1 }), /nonnegative/);
+	await assert.rejects(f.store.history({ threadId, op: "list", limit: 0 }), /positive/);
+	await assert.rejects(f.store.history({ threadId, op: "read", id: "ordinal:999" }), /not found/);
+	await assert.rejects(f.store.notes({ threadId, op: "read", path: "missing.md" }), { code: "ENOENT" });
+	await assert.rejects(f.store.history({ threadId: "unregistered", op: "list" }), /No transcript registered/);
+});
+
+test("failed checkpoint leaves the prior recovery intact and never modifies the transcript", async () => {
+	const f = await fixture([user("KEEP_VALID_CHECKPOINT")]);
+	await f.store.checkpoint(f.hook);
+	const previous = await f.store.threadHint(threadId);
+	await writeFile(f.transcript, f.original + '{"type":"response_item","payload":');
+	await assert.rejects(f.store.checkpoint(f.hook), /incomplete or invalid JSON/);
+	assert.equal(await f.store.threadHint(threadId), previous);
+	const partial = await readFile(f.transcript, "utf8");
+	assert.equal(partial, f.original + '{"type":"response_item","payload":');
+	await writeFile(f.transcript, f.original);
+	const invalidState = join(f.dir, "not-a-directory");
+	await writeFile(invalidState, "occupied");
+	await assert.rejects(createStore(invalidState).checkpoint(f.hook));
+	assert.equal(await readFile(f.transcript, "utf8"), f.original);
+	assert.equal(await readFile(invalidState, "utf8"), "occupied");
+	await assert.rejects(f.store.checkpoint({ ...f.hook, session_id: "wrong-thread" }), /session ID does not match/);
+});
+
+test("child hooks use agent_id while preserving the root task's checkpoint and notes", async () => {
+	const f = await fixture([user("PARENT_REQUEST keep parent work intact")]);
+	await f.store.checkpoint(f.hook);
+	await f.store.notes({ threadId, op: "write", path: "current.md", content: "Parent notes" });
+	const parentHint = await f.store.threadHint(threadId);
+	const childId = "child-thread";
+	const childTranscript = join(f.dir, "child-rollout.jsonl");
+	const childRows = [
+		{ type: "session_meta", payload: { id: childId, session_id: threadId, parent_thread_id: threadId } },
+		user("CHILD_REQUEST complete the delegated check"),
+		call("child-call"), output("child-call", "CHILD_UNREAD_RESULT"), tokenCount,
+	].map((row, ordinal) => ({ ordinal, ...row }));
+	await writeFile(childTranscript, childRows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+	const childHook = { ...f.hook, agent_id: childId, transcript_path: childTranscript };
+	await f.store.register(childHook);
+	const childCheckpoint = await f.store.checkpoint(childHook);
+	assert.equal(childCheckpoint.threadId, childId);
+	assert.equal(childCheckpoint.rootThreadId, threadId);
+	assert.match(childCheckpoint.recovery, /CHILD_REQUEST/);
+	assert.match(childCheckpoint.recovery, /CHILD_UNREAD_RESULT/);
+	assert.match(childCheckpoint.recovery, /original delegated task input/);
+	assert.match(childCheckpoint.recovery, /not direct user authorization/);
+	assert.doesNotMatch(childCheckpoint.recovery, /direct user input/);
+	assert.doesNotMatch(childCheckpoint.recovery, /PARENT_REQUEST/);
+	await f.store.notes({ threadId: childId, op: "write", path: "current.md", content: "Child notes" });
+	const restarted = createStore(f.stateDir);
+	assert.equal(await restarted.threadHint(threadId), parentHint);
+	assert.match(await restarted.threadHint(childId), /CHILD_UNREAD_RESULT/);
+	assert.equal((await restarted.notes({ threadId, op: "read", path: "current.md" })).content, "Parent notes");
+	assert.equal((await restarted.notes({ threadId: childId, op: "read", path: "current.md" })).content, "Child notes");
+	const parentManifest = JSON.parse(await readFile(join(f.stateDir, "threads", `${threadId}.json`), "utf8"));
+	const childManifest = JSON.parse(await readFile(join(f.stateDir, "threads", `${childId}.json`), "utf8"));
+	assert.equal(parentManifest.transcriptPath, f.transcript);
+	assert.equal(childManifest.transcriptPath, childTranscript);
+	assert.equal(childManifest.rootThreadId, threadId);
+	assert.notEqual(parentManifest.checkpointPath, childManifest.checkpointPath);
+	assert.match((await restarted.history({ threadId: childId, op: "read", id: "ordinal:1" })).content, /CHILD_REQUEST/);
+	await assert.rejects(restarted.checkpoint({ ...childHook, agent_id: "wrong-child" }), /session ID does not match/);
+});


### PR DESCRIPTION
## Summary

Add an isolated Codex adapter prototype under `adapters/codex-posthorse`. It reuses Codex's local token-budget reset, a direct local `notes` MCP server, and hooks to preserve recoverable task inputs and original history.

This is a draft proof, not a supported desktop installation. It does not change the Pi implementation, published package, daily Codex configuration, account eligibility, or desktop runtime.

## Included

- Task-local durable notes, paged/searchable original JSONL history, image recovery, and bounded pre-reset records.
- Root/child task separation, native window IDs, and authority labels that do not promote delegated prompts into user permission.
- Plugin scaffold and real MCP/hook tests.
- Real Codex 0.153.4 app-server tests using scripted local model replies and isolated state. No real inference or account credentials.
- Adapter and pinned-runtime CI, with retained runtime evidence.

## Verification

- Pi tests: 39 passed; TypeScript check passed.
- Adapter tests: 13 passed; dependency audit: 0 vulnerabilities.
- Plugin validator and diff whitespace check passed.
- Runtime characterization: 5 passed, reporting known unmet acceptance.
- Strict acceptance: **2 passed, 3 failed, exit 1**. These failures are retained deliberately, not marked TODO or skipped.

Automatic recovery and restart work. A handled filesystem checkpoint failure stops reset. Stock Codex still changes manual `/compact` into a no-summary reset and commits explicit reset after a sibling shell or MCP tool fails. Hook crashes/timeouts can also allow reset, based on source inspection.

**Green CI characterizes the current runtime; it does not mean full Posthorse acceptance.** Run `npm run test:acceptance` in the adapter to enforce the stronger readiness requirements. Real Astra inference, 500k-token usage, installed desktop behavior, and real multi-agent rollover remain untested.

## Follow-up boundary

No installation or runtime fork is included. Correcting the native failures requires a separate decision about maintaining focused Codex runtime changes. No merge or release requested.
