### PR TITLE
Verify local Codex recovery against a pinned native runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   # Known-good fitchmultz/pi revision for the integration job; keep in step with the README.
   PI_FORK_REF: f9b06177e565f70cd243a785d088d1c491830dbd
+  CODEX_LOCAL_REF: 6c5d489f76b358ff6adedcf47211081d290b293b
 
 jobs:
   test:
@@ -97,4 +98,75 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: codex-runtime-evidence
+          path: ~/Library/Caches/pi-runs/posthorse-codex-*
+
+  codex-local-recovery:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      CODEX_REPO_ROOT: ${{ github.workspace }}/native-codex
+      CARGO_TARGET_DIR: ${{ runner.temp }}/codex-posthorse-target
+      CARGO_BUILD_JOBS: 2
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
+        with:
+          repository: fitchmultz/codex
+          ref: ${{ env.CODEX_LOCAL_REF }}
+          path: native-codex
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: adapters/codex-posthorse/package-lock.json
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582
+        with:
+          components: rust-src
+      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
+        with:
+          tool: just@1.51.0,cargo-nextest@0.9.143
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential pkg-config libcap-dev libasound2-dev bubblewrap
+      - name: Resolve repository-pinned V8 artifacts
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import os
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, str(Path(os.environ["CODEX_REPO_ROOT"]) / "scripts"))
+          from codex_package.targets import TARGET_SPECS
+          from codex_package.v8 import resolve_codex_v8_cargo_env
+          overrides = resolve_codex_v8_cargo_env(
+              TARGET_SPECS["x86_64-unknown-linux-gnu"],
+              cache_root=Path(os.environ["RUNNER_TEMP"]) / "codex-v8",
+          )
+          for key, value in overrides.items():
+              print(f"{key}={value}")
+          PY
+      - name: Build matching CLI and code-mode host
+        working-directory: native-codex/codex-rs
+        run: cargo build --locked -p codex-cli --bin codex -p codex-code-mode-host --bin codex-code-mode-host
+      - name: Test native hook and feature configuration
+        working-directory: native-codex/codex-rs
+        run: just test -p codex-hooks -p codex-features
+      - run: npm ci --ignore-scripts
+        working-directory: adapters/codex-posthorse
+      - name: Enforce local recovery acceptance
+        working-directory: adapters/codex-posthorse
+        env:
+          POSTHORSE_CODEX_BIN: ${{ runner.temp }}/codex-posthorse-target/debug/codex
+        run: npm run test:local
+      - name: Save local recovery evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-local-recovery-evidence
           path: ~/Library/Caches/pi-runs/posthorse-codex-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
       contents: read
     env:
       CODEX_REPO_ROOT: ${{ github.workspace }}/native-codex
-      CARGO_TARGET_DIR: ${{ runner.temp }}/codex-posthorse-target
       CARGO_BUILD_JOBS: 2
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 0
@@ -135,8 +134,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends build-essential pkg-config libcap-dev libasound2-dev bubblewrap
-      - name: Resolve repository-pinned V8 artifacts
+      - name: Prepare native build environment
         run: |
+          echo "CARGO_TARGET_DIR=$RUNNER_TEMP/codex-posthorse-target" >> "$GITHUB_ENV"
           python3 - <<'PY' >> "$GITHUB_ENV"
           import os
           import sys

--- a/adapters/codex-posthorse/README.md
+++ b/adapters/codex-posthorse/README.md
@@ -2,20 +2,23 @@
 
 An isolated proof of Posthorse-style context recovery using Codex's existing local context-reset path, a local tool server, and hooks. It does not replace Pi Posthorse, change the Pi package, or enable Codex's account-gated remote context-management service.
 
-**Not ready for everyday tasks.** Automatic recovery and restart work in controlled real-runtime tests, but stock Codex does not meet all Posthorse requirements. Nothing here installs itself, changes your normal Codex configuration, or replaces the desktop runtime.
+**Isolated testing only.** The companion local-recovery runtime patch passes the controlled recovery checks. Stock Codex does not meet all of them, and installed desktop behavior and real-model workloads have not been validated. Nothing here installs itself, changes your normal Codex configuration, or replaces the desktop runtime.
 
 ## What has been proved
 
-Tests run the actual Codex `0.153.4` app-server, actual command tools, actual hooks, and the actual local MCP server. A local HTTP fixture supplies scripted model replies and usage counts. No real model inference or account credentials are involved.
+Tests run the actual app-server, command tools, hooks, local MCP server, and matching code-mode host. Stock baselines include Codex `0.153.4` and upstream commit `4f2449b4b21988d5015ce6edf755fbd6a37a4908`. A local HTTP fixture supplies scripted model replies and usage counts. No real model inference or account credentials are involved.
 
-| Requirement | Observed result with Codex 0.153.4 |
-| --- | --- |
-| Automatic reset keeps original requests and unread tool output recoverable | Pass: the next model request contains recovery text from the local notes bridge after the native window changes. |
-| Notes and original history survive restart | Pass: real tool calls read the saved note and original tool output after restarting the runtime. |
-| A handled checkpoint-write failure stops reset | Pass: an actual filesystem error stops the turn before any context boundary is committed. |
-| Manual `/compact` keeps ordinary summarization | Fail: local token-budget mode resets without a summary request; ordinary mode makes one. |
-| A failed command beside `new_context` cancels reset | Fail: a command exits 7, but the window still changes. Its error remains recoverable. |
-| A failed MCP tool beside `new_context` cancels reset | Fail: Codex reports the tool as failed, but the window still changes. |
+| Requirement | Stock token-budget mode | Patched local recovery |
+| --- | --- | --- |
+| Original requests and unread output recover after automatic reset | Pass | Pass |
+| Notes and original history survive restart | Pass | Pass, including retry after repairing a failed checkpoint write |
+| Handled checkpoint-write error stops reset | Pass | Pass |
+| Manual `/compact` keeps ordinary summarization | Fails: resets without a summary | Pass |
+| Failed shell or MCP sibling cancels `new_context` | Fails: reset still commits | Pass, including both completion orders and the automatic threshold |
+| Required hook must be available and successful | No required-hook policy; a process failure allows reset | Pass for missing, disabled, untrusted, unmatched, asynchronous, failed, timed-out, and malformed-output hooks |
+| Invalid recovery hint cannot silently reset context | Fails | Pass: clear stop before reset; invalid initial hints are omitted with a warning |
+
+The strict local suite has 22 passing scenarios. It also covers caught nested errors and malformed nested arguments through advertised code-mode tools, later successful reset after a handled failure, and oversized saved hints on initial context loading. Adapter tests cover Unicode byte limits and exact original-history recovery.
 
 The fixture selects the `gpt-6-astra` model identifier. This proves runtime wiring, not Astra's behavior, a 500,000-token workload, or usability inside the desktop app. The tests use a 50,000-token configured window and synthetic usage crossing a 9,000-token threshold to make rollover reproducible.
 
@@ -23,10 +26,10 @@ The fixture selects the `gpt-6-astra` model identifier. This proves runtime wiri
 
 1. `SessionStart` and `SubagentStart` register the current task's original transcript path. A child uses its own `agent_id`; `session_id` remains the root task ID.
 2. `PreCompact` saves a bounded recovery record before the runtime resets context. It prioritizes the first and latest original inputs, then trailing tool results, with record IDs for retrieving omitted material. It does not turn assistant progress claims into completed state.
-3. Codex starts a new native context window and calls `notes.thread_hint`. The hint restores task identity, recovery text, and instructions for reading durable notes and original history.
+3. The patched local mode reads and validates `notes.thread_hint` before changing windows, then uses that exact text in the fresh window. The hint restores task identity, recovery text, and instructions for reading durable notes and original history.
 4. Notes and checkpoints remain on disk. History reads the original Codex JSONL transcript without rewriting or deleting it.
 
-The recovery record is capped at 20,000 characters, with individual excerpts capped at 4,000. Full records remain available in pages. Older summaries are not copied into new recovery records. Child task prompts are labeled as delegated input, not promoted to direct user authorization.
+The recovery record is capped at 20,000 characters, with individual excerpts capped at 4,000 and the entire hint capped at 32,000 UTF-8 bytes. Unicode excerpts preserve complete characters. Full records remain available in pages. Older summaries are not copied into new recovery records. Child task prompts are labeled as delegated input, not promoted to direct user authorization.
 
 Codex does not persist exact model acknowledgement of each tool result. The adapter infers unread results from the recorded tool batch and subsequent assistant output, and labels that inference explicitly. Recovery text is a record of inputs, not proof that work succeeded; the model must read notes and verify current state before continuing external actions.
 
@@ -42,7 +45,7 @@ The tool server does not make network requests. Returned notes and history becom
 
 ## Run the isolated tests
 
-Requirements: Node `>=22.19.0`, and Codex `0.153.4` for runtime tests. From this directory:
+Requirements: Node `>=22.19.0`, stock Codex `0.153.4` for the pinned comparison, or the companion patched CLI and matching code-mode host for local acceptance. From this directory:
 
 ```bash
 npm ci --ignore-scripts
@@ -51,9 +54,19 @@ npm run test:runtime
 npm run test:acceptance
 ```
 
-Set `POSTHORSE_CODEX_BIN` to an explicit executable path to test a different runtime. The last command currently exits nonzero on stock `0.153.4`: two runtime scenarios pass and three fail the required acceptance checks. This is intentional and must not be read as approval to enable the prototype.
+Set `POSTHORSE_CODEX_BIN` to an explicit executable path to test a different runtime. `test:acceptance` still exits nonzero in stock mode because manual summarization and the two failed-sibling requirements are unmet. The separate stock hook-process-error check confirms existing behavior; it is not approval of that behavior.
 
-`test:runtime` checks wiring and records the observed native behavior, printing `UNMET ACCEPTANCE` for known gaps. CI runs that characterization suite so platform changes and broken wiring are visible. **Green CI does not mean full Posthorse behavior is supported.** `test:acceptance` enforces the stronger requirements and is the readiness check.
+For the patched local policy, place both binaries in the same directory and run:
+
+```bash
+POSTHORSE_CODEX_BIN=/absolute/path/to/codex npm run test:local
+```
+
+`test:local` enables `POSTHORSE_LOCAL_RECOVERY=1` and strict acceptance. The harness discovers the real `PreCompact` hook key and sets `features.token_budget.local_recovery_hook` only in each temporary home. No account-gated remote feature is enabled.
+
+`test:runtime` characterizes stock behavior and prints `UNMET ACCEPTANCE` for its known gaps. Local acceptance enforces the stronger requirements without skips or TODOs. A passing controlled suite does not establish desktop compatibility or real-model quality.
+
+CI keeps the stock comparison and builds a pinned companion runtime for a separate local-acceptance job. That job builds the matching code-mode host, runs native hook/feature tests, and exercises the full local runtime suite. The Codex reference fork's inherited GitHub Actions remain disabled; these consumer checks do not depend on its upstream-specific runners.
 
 Each runtime case creates a separate `CODEX_HOME`, workspace, and state directory under `~/Library/Caches/pi-runs/posthorse-codex-*`, even on Linux. It never imports the normal Codex configuration or credentials. The harness trusts only its own test hooks, uses a loopback model endpoint, and terminates only processes it started. Transcripts, model requests, runtime events, errors, and `acceptance.json` results remain there for inspection; tests do not remove them. Unit and MCP test scratch data is retained under the same cache root.
 
@@ -61,8 +74,8 @@ Each runtime case creates a separate `CODEX_HOME`, workspace, and state director
 
 The plugin manifest and companion hook/MCP files are a scaffold, not a tested desktop installation path. The native bridge currently looks for a direct MCP server named `notes`; a plugin-namespaced server is not enough to assume it will connect. Runtime tests register that direct server explicitly in the isolated configuration and disable the remote history/notes extension.
 
-Handled hook errors return `continue: false` while exiting successfully, because stock Codex can proceed after a bare hook process failure. A crash, import failure, or timeout can still allow reset without a fresh checkpoint. `SubagentStart` also ignores stop requests, so a failed child registration cannot prevent the child from starting. These are runtime limitations, not fixed by the adapter.
+Handled hook errors return `continue: false` while exiting successfully for stock compatibility. Stock Codex can proceed after a bare hook process failure; patched local mode requires the selected synchronous hook to finish successfully. `SubagentStart` still ignores stop requests, so a failed child registration cannot prevent the child from starting.
 
 This prototype does not add Pi's proactive checkpoint reminder, context-aware page sizing, shared repository notes, or custom tool cards. Parent/child storage separation is tested at the store layer; a real multi-agent rollover and the installed desktop plugin path have not been tested.
 
-Full Posthorse behavior needs changes in the Codex runtime: retain ordinary manual summarization, cancel a pending explicit reset when its tool batch fails, and stop safely when required checkpoint hooks cannot run. The prototype uses the stock runtime and does not include or install those changes.
+The companion runtime patch supplies ordinary manual summarization, failed-batch cancellation, required-checkpoint enforcement, and validated hint loading. It remains an explicit local opt-in. The adapter does not install the patch or change which runtime the desktop app uses.

--- a/adapters/codex-posthorse/package.json
+++ b/adapters/codex-posthorse/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "node --test test/store.test.mjs test/server.test.mjs",
     "test:runtime": "node --test test/runtime.test.mjs",
-    "test:acceptance": "POSTHORSE_ACCEPTANCE=1 node --test test/runtime.test.mjs"
+    "test:acceptance": "POSTHORSE_ACCEPTANCE=1 node --test test/runtime.test.mjs",
+    "test:local": "POSTHORSE_LOCAL_RECOVERY=1 POSTHORSE_ACCEPTANCE=1 node --test test/runtime.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.30.0"

--- a/adapters/codex-posthorse/store.mjs
+++ b/adapters/codex-posthorse/store.mjs
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 
 const MAX_HANDOFF_CHARS = 20_000;
+const MAX_HINT_BYTES = 32_000;
 const MAX_RECORD_CHARS = 4_000;
 const TOOL_CALLS = new Set(["function_call", "custom_tool_call", "local_shell_call"]);
 const TOOL_OUTPUTS = new Set(["function_call_output", "custom_tool_call_output", "local_shell_call_output"]);
@@ -154,12 +155,33 @@ function ownerLabel(record) {
 		? "direct user input" : "original user-role input";
 }
 
-function excerpt(text, limit) {
-	if (text.length <= limit) return text;
-	const marker = "\n… omitted; use history read for the original …\n";
-	if (limit <= marker.length) return text.slice(0, limit);
-	const half = Math.floor((limit - marker.length) / 2);
-	return `${text.slice(0, half)}${marker}${text.slice(text.length - (limit - marker.length - half))}`;
+function excerpt(text, limit, maxBytes) {
+	const render = (size) => {
+		if (text.length <= size) return text;
+		const marker = "\n… omitted; use history read for the original …\n";
+		if (size <= marker.length) return text.slice(0, size).replace(/\p{Surrogate}$/u, "");
+		const half = Math.floor((size - marker.length) / 2);
+		const head = text.slice(0, half).replace(/\p{Surrogate}$/u, "");
+		const tail = text.slice(text.length - (size - marker.length - half)).replace(/^\p{Surrogate}/u, "");
+		return `${head}${marker}${tail}`;
+	};
+	const initial = render(limit);
+	if (Buffer.byteLength(initial) <= maxBytes) return initial;
+	let low = 0;
+	let high = limit;
+	while (low < high) {
+		const middle = Math.ceil((low + high) / 2);
+		if (Buffer.byteLength(render(middle)) <= maxBytes) low = middle;
+		else high = middle - 1;
+	}
+	return render(low);
+}
+
+function hintGuidance(threadId) {
+	return [
+		`Posthorse task ID: ${threadId}. Pass threadId: ${JSON.stringify(threadId)} to notes and history tools.`,
+		"Keep durable decisions, current work, verification, and outstanding user requests in notes. Use notes with op list/read/write/append/search and a relative path. Use history with op list/search/read; copy a record id from list/search, then read it with offset/limit pages. Original image blocks remain in history records. Context boundaries are labeled by windowId. Save current notes before automatic rollover.",
+	].join("\n\n");
 }
 
 async function recoveryFrom(file, threadId, rootThreadId) {
@@ -222,15 +244,17 @@ async function recoveryFrom(file, threadId, rootThreadId) {
 	].join("\n\n");
 	const selected = [];
 	let available = MAX_HANDOFF_CHARS - prefix.length - 1_000;
+	let availableBytes = MAX_HINT_BYTES - Buffer.byteLength(prefix + hintGuidance(threadId)) - 1_000;
 	for (const { record, label } of chosen.values()) {
 		const header = `[${label} | ${record.id} | window ${record.windowId}]`;
-		if (available < header.length + 200) continue;
+		if (available < header.length + 200 || availableBytes < Buffer.byteLength(header) + 200) continue;
 		const call = calls.get(record.row.payload?.call_id);
 		const body = `${recordText(record.row)}${call ? `\n\nTool call ${call.id}: ${recordText(call.row)}` : ""}`;
 		const limit = Math.min(MAX_RECORD_CHARS, available);
-		const block = `${header}\n${excerpt(body, limit - header.length - 1)}`;
+		const block = `${header}\n${excerpt(body, limit - header.length - 1, availableBytes - Buffer.byteLength(header) - 1)}`;
 		selected.push({ line: record.line, id: record.id, block });
 		available -= block.length + 2;
+		availableBytes -= Buffer.byteLength(block) + 2;
 	}
 	selected.sort((a, b) => a.line - b.line);
 	const omissions = chosen.size - selected.length;
@@ -239,9 +263,13 @@ async function recoveryFrom(file, threadId, rootThreadId) {
 		boundary ? `Previous context boundary: ${boundary.id}. History read preserves its original checkpoint; summaries are not nested here.` : "",
 		`Checkpoint covers transcript through ${last.id} (line ${last.line}). Use notes list/read for durable state; use history read with an id to retrieve the original record in pages.`,
 	].filter(Boolean).join("\n\n");
+	const recovery = [prefix, ...selected.map((item) => item.block), suffix].join("\n\n");
+	if (Buffer.byteLength(`${recovery}\n\n${hintGuidance(threadId)}`) > MAX_HINT_BYTES) {
+		throw new Error("Recovery metadata exceeds the context hint limit; checkpoint was not accepted.");
+	}
 	return {
 		throughId: last.id, throughLine: last.line, throughOrdinal: last.ordinal, windowId: last.windowId,
-		recovery: [prefix, ...selected.map((item) => item.block), suffix].join("\n\n"),
+		recovery,
 	};
 }
 
@@ -315,8 +343,7 @@ export function createStore(stateDir) {
 		if (manifest?.checkpointPath && !checkpoint) throw new Error("Saved checkpoint is missing; recovery cannot be confirmed.");
 		return [
 			checkpoint?.recovery,
-			`Posthorse task ID: ${threadId}. Pass threadId: ${JSON.stringify(threadId)} to notes and history tools.`,
-			"Keep durable decisions, current work, verification, and outstanding user requests in notes. Use notes with op list/read/write/append/search and a relative path. Use history with op list/search/read; copy a record id from list/search, then read it with offset/limit pages. Original image blocks remain in history records. Context boundaries are labeled by windowId. Save current notes before automatic rollover.",
+			hintGuidance(threadId),
 		].filter(Boolean).join("\n\n");
 	}
 	async function notes(params) {

--- a/adapters/codex-posthorse/test/runtime-harness.mjs
+++ b/adapters/codex-posthorse/test/runtime-harness.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import { createInterface } from "node:readline";
 import { mkdir, mkdtemp, readFile, writeFile, appendFile, rename } from "node:fs/promises";
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
 
 const adapter = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const timeoutMs = 30_000;
@@ -32,13 +33,21 @@ export function contextWindow(request) {
 }
 
 export class RuntimeHarness {
-	static async create(name, { tokenBudget = true, failCheckpoint = false } = {}) {
+	static async create(name, {
+		tokenBudget = true, failCheckpoint = false, hookFailure, hintFailure, recordToolCompletions = false,
+		localRecovery = process.env.POSTHORSE_LOCAL_RECOVERY === "1", codeMode = false,
+	} = {}) {
 		const cache = join(homedir(), "Library", "Caches", "pi-runs");
 		await mkdir(cache, { recursive: true });
 		const root = await mkdtemp(join(cache, `posthorse-codex-${name}-`));
 		const harness = new RuntimeHarness(root);
 		harness.tokenBudget = tokenBudget;
 		harness.failCheckpoint = failCheckpoint;
+		harness.localRecovery = localRecovery && tokenBudget;
+		harness.hookFailure = hookFailure;
+		harness.hintFailure = hintFailure;
+		harness.recordToolCompletions = recordToolCompletions;
+		harness.codeMode = codeMode;
 		try {
 			await harness.initialize();
 			return harness;
@@ -92,7 +101,10 @@ export class RuntimeHarness {
 					} } },
 				];
 				res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" });
-				for (const event of events) res.write(`data: ${JSON.stringify(event)}\n\n`);
+				for (const event of events) {
+					res.write(`data: ${JSON.stringify(event)}\n\n`);
+					if (reply.betweenItemsMs && event.type === "response.output_item.done") await delay(reply.betweenItemsMs);
+				}
 				res.end();
 			} catch (error) {
 				this.providerError = error;
@@ -102,8 +114,18 @@ export class RuntimeHarness {
 		});
 		this.server.listen(0, "127.0.0.1");
 		await once(this.server, "listening");
-		const hookCommand = `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "precompact.mjs"))}`;
+		const hookCommand = this.hintFailure || ["nonzero", "timeout", "malformed"].includes(this.hookFailure)
+			? `${shellQuote(process.execPath)} ${shellQuote(fileURLToPath(import.meta.url))} --hook-fixture ${this.hintFailure ? `checkpoint-then-${this.hintFailure}-hint` : this.hookFailure}`
+			: `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "precompact.mjs"))}`;
 		const sessionCommand = `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "session-start.mjs"))}`;
+		const completionCommand = `${shellQuote(process.execPath)} ${shellQuote(fileURLToPath(import.meta.url))} --hook-fixture record-completion`;
+		const preCompactConfig = [
+			'[[hooks.PreCompact]]',
+			...(this.hookFailure === "unmatched" ? ['matcher = "manual"'] : []),
+			'[[hooks.PreCompact.hooks]]', 'type = "command"', `command = ${quote(hookCommand)}`,
+			...(this.hookFailure === "async" ? ['async = true'] : []),
+			...(this.hookFailure === "timeout" ? ['timeout = 1'] : []),
+		].join("\n") + "\n";
 		this.config = [
 			'model = "gpt-6-astra"', 'model_provider = "posthorse_fixture"',
 			'model_context_window = 50000', 'model_auto_compact_token_limit = 9000',
@@ -111,7 +133,7 @@ export class RuntimeHarness {
 			'web_search = "disabled"',
 			'[features]', 'context_management = false', 'apps = false', 'remote_plugin = false',
 			'memories = false', 'multi_agent = false', 'shell_snapshot = false', 'hooks = true',
-			'code_mode_host = false',
+			`code_mode_host = ${this.codeMode}`,
 			'[features.token_budget]', `enabled = ${this.tokenBudget}`, 'use_history_notes_extension = false',
 			'guidance_message = "Use the local notes and history tools to recover durable Posthorse state."',
 			'[model_providers.posthorse_fixture]', 'name = "Posthorse local test"',
@@ -121,10 +143,10 @@ export class RuntimeHarness {
 			'[mcp_servers.notes]', `command = ${quote(process.execPath)}`,
 			`args = [${quote(join(adapter, "server.mjs"))}]`,
 			'[mcp_servers.notes.env]', `POSTHORSE_STATE_DIR = ${quote(this.state)}`,
-			'[[hooks.PreCompact]]',
-			'[[hooks.PreCompact.hooks]]', 'type = "command"', `command = ${quote(hookCommand)}`,
+			preCompactConfig.trimEnd(),
 			'[[hooks.SessionStart]]',
 			'[[hooks.SessionStart.hooks]]', 'type = "command"', `command = ${quote(sessionCommand)}`,
+			...(this.recordToolCompletions ? ['[[hooks.PostToolUse]]', '[[hooks.PostToolUse.hooks]]', 'type = "command"', `command = ${quote(completionCommand)}`] : []),
 			`[projects.${quote(this.cwd)}]`, 'trust_level = "trusted"',
 		].join("\n") + "\n";
 		await writeFile(join(this.home, "config.toml"), this.config);
@@ -133,8 +155,16 @@ export class RuntimeHarness {
 		await writeFile(join(this.root, "hooks-list.json"), JSON.stringify(listed, null, 2));
 		const hooks = listed.data.flatMap((entry) => entry.hooks ?? []);
 		if (!hooks.length) throw new Error(`No hooks discovered: ${JSON.stringify(listed)}`);
+		const recoveryHook = hooks.find((hook) => hook.eventName === "preCompact");
+		if (!recoveryHook) throw new Error("No PreCompact hook discovered");
 		await this.stop();
-		for (const hook of hooks) this.config += `\n[hooks.state.${quote(hook.key)}]\ntrusted_hash = ${quote(hook.currentHash)}\n`;
+		if (this.localRecovery) this.config = this.config.replace('[features.token_budget]\n', `[features.token_budget]\nlocal_recovery_hook = ${quote(recoveryHook.key)}\n`);
+		if (this.hookFailure === "missing") this.config = this.config.replace(preCompactConfig, "");
+		for (const hook of hooks) {
+			if (hook.key === recoveryHook.key && this.hookFailure === "untrusted") continue;
+			this.config += `\n[hooks.state.${quote(hook.key)}]\ntrusted_hash = ${quote(hook.currentHash)}\n`;
+			if (hook.key === recoveryHook.key && this.hookFailure === "disabled") this.config += 'enabled = false\n';
+		}
 		await writeFile(join(this.home, "config.toml"), this.config);
 		await this.start();
 	}
@@ -269,5 +299,46 @@ export class RuntimeHarness {
 		await this.stop();
 		if (this.server?.listening) await new Promise((resolveClosed) => this.server.close(resolveClosed));
 		await this.logWrites;
+	}
+}
+
+if (process.argv[2] === "--hook-fixture") {
+	let input = "";
+	for await (const chunk of process.stdin) input += chunk;
+	const payload = JSON.parse(input);
+	await appendFile(join(dirname(process.env.CODEX_HOME), "hook-fixture.jsonl"), `${JSON.stringify({ recordedAt: Date.now(), ...payload })}\n`);
+	switch (process.argv[3]) {
+		case "record-completion":
+			process.stdout.write("{}\n");
+			break;
+		case "nonzero":
+			process.stderr.write("CONTROLLED_CHECKPOINT_PROCESS_FAILURE\n");
+			process.exitCode = 7;
+			break;
+		case "malformed":
+			process.stdout.write('{"continue": INVALID_JSON\n');
+			break;
+		case "timeout":
+			await delay(10_000);
+			break;
+		case "checkpoint-then-invalid-json-hint":
+		case "checkpoint-then-oversize-hint": {
+			const checkpoint = spawnSync(process.execPath, [join(adapter, "scripts", "precompact.mjs")], { input, encoding: "utf8" });
+			if (checkpoint.status !== 0 || JSON.parse(checkpoint.stdout).continue !== true) throw new Error(`Production checkpoint failed: ${checkpoint.stderr} ${checkpoint.stdout}`);
+			const manifest = join(process.env.POSTHORSE_STATE_DIR, "threads", `${payload.agent_id ?? payload.session_id}.json`);
+			if (process.argv[3] === "checkpoint-then-invalid-json-hint") {
+				await rename(manifest, `${manifest}.before-hint-failure`);
+				await writeFile(manifest, '{"CONTROLLED_INVALID_RECOVERY_HINT":');
+			} else {
+				const { checkpointPath } = JSON.parse(await readFile(manifest, "utf8"));
+				const recovery = JSON.parse(await readFile(checkpointPath, "utf8"));
+				await rename(checkpointPath, `${checkpointPath}.before-hint-failure`);
+				await writeFile(checkpointPath, JSON.stringify({ ...recovery, recovery: "😀".repeat(9_000) }));
+			}
+			process.stdout.write(checkpoint.stdout);
+			break;
+		}
+		default:
+			throw new Error(`Unknown hook fixture: ${process.argv[3]}`);
 	}
 }

--- a/adapters/codex-posthorse/test/runtime.test.mjs
+++ b/adapters/codex-posthorse/test/runtime.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { RuntimeHarness, call, message, contextWindow, requestText, discoverNotes } from "./runtime-harness.mjs";
 
 const acceptance = process.env.POSTHORSE_ACCEPTANCE === "1";
+const localRecovery = process.env.POSTHORSE_LOCAL_RECOVERY === "1";
 const ownerRequest = "OWNER_REQUEST_47: preserve this instruction and finish the recovery proof.";
 const unreadResult = "UNREAD_TOOL_RESULT_83";
 const failedResult = "FAILED_SIBLING_RESULT_59";
@@ -22,7 +24,14 @@ async function recordAcceptance(t, h, name, passed, detail) {
 		threadId: h.threadId, transcript: h.transcript,
 	}, null, 2) + "\n");
 	if (!passed) t.diagnostic(`UNMET ACCEPTANCE: ${detail}`);
-	if (acceptance) assert.ok(passed, detail);
+	if (acceptance || localRecovery) assert.ok(passed, detail);
+}
+
+function visibleFailure(h, turn) {
+	return Boolean(turn.error?.message) || h.events.some((event) =>
+		(event.method === "error" && event.params.error?.message) ||
+		(event.method === "warning" && /recovery|context was not reset/i.test(event.params.message)) ||
+		(event.method === "hook/completed" && ["failed", "stopped"].includes(event.params.run.status) && event.params.run.entries.some((entry) => entry.text)));
 }
 
 test("automatic rollover restores user instructions and unread output through the real notes bridge, then survives restart", async (t) => {
@@ -81,9 +90,170 @@ test("a failed checkpoint stops automatic rollover and preserves the original tr
 		assert.equal(transcript.filter((entry) => entry.type === "compacted").length, 0);
 		assert.ok(JSON.stringify(transcript).includes(ownerRequest));
 		assert.ok(JSON.stringify(transcript).includes(unreadResult));
+		assert.ok(visibleFailure(h, turn), "the stopped checkpoint must explain the failure to the client");
+		await rename(h.state, `${h.state}-blocked-path`);
+		await rename(`${h.state}-before-failure`, h.state);
+		await h.restart();
+		const retry = await h.turn("Retry the same task after restoring checkpoint storage.", [{ items: [message("recovered after checkpoint repair")] }]);
+		assert.equal(retry.status, "completed");
+		assert.match(requestText(h.requests.at(-1)), /OWNER_REQUEST_47/);
+		assert.match(requestText(h.requests.at(-1)), /UNREAD_TOOL_RESULT_83/);
+		assert.notEqual(contextWindow(h.requests.at(-1)), contextWindow(h.requests[0]));
 		await recordAcceptance(t, h, "checkpoint-failure", true, "A real filesystem checkpoint failure stops rollover without removing original history.");
 	});
 });
+
+test("stock opt-out still permits rollover after a hook process exits nonzero", async (t) => {
+	await usingRuntime(t, "stock-hook-crash", { localRecovery: false, hookFailure: "nonzero" }, async (h) => {
+		const turn = await h.turn(ownerRequest, [
+			{ items: [call("exec_command", { cmd: `printf '${unreadResult}\\n'`, login: false }, "stock-unread-output")], tokens: 9_500 },
+			{ items: [message("stock continuation")] },
+		]);
+		assert.equal(turn.status, "completed");
+		assert.equal(h.requests.length, 2);
+		assert.notEqual(contextWindow(h.requests[1]), contextWindow(h.requests[0]));
+		assert.ok(h.events.some((event) => event.method === "hook/completed" && event.params.run.eventName === "preCompact" && event.params.run.status === "failed"));
+		assert.match(JSON.stringify(await h.transcriptItems()), /UNREAD_TOOL_RESULT_83/);
+	});
+});
+
+if (localRecovery) {
+	test("an oversized pre-existing hint is rejected during initial context loading without hiding the new request", async (t) => {
+		await usingRuntime(t, "initial-oversize-hint", {}, async (h) => {
+			const id = randomUUID();
+			const directory = join(h.state, "checkpoints", h.threadId);
+			await mkdir(directory, { recursive: true });
+			await mkdir(join(h.state, "threads"), { recursive: true });
+			const checkpointPath = join(directory, `${id}.json`);
+			const identity = { version: 1, threadId: h.threadId, rootThreadId: h.threadId, transcriptPath: h.transcript };
+			await writeFile(checkpointPath, JSON.stringify({ ...identity, id, trigger: "auto", recovery: "INITIAL_OVERSIZE_MARKER_67" + "😀".repeat(9_000) }));
+			await writeFile(join(h.state, "threads", `${h.threadId}.json`), JSON.stringify({ ...identity, checkpointPath }));
+			const turn = await h.turn(ownerRequest, [{ items: [message("new request completed") ] }]);
+			assert.equal(turn.status, "completed");
+			assert.equal(h.requests.length, 1);
+			assert.ok(!requestText(h.requests[0]).includes("INITIAL_OVERSIZE_MARKER_67"), "initial prompt construction must use the same bounded hint validation as rollover");
+			assert.match(requestText(h.requests[0]), /OWNER_REQUEST_47/);
+			assert.ok(visibleFailure(h, turn), "ignored recovery state must be explained, not silently discarded");
+			assert.ok(Buffer.byteLength(await readFile(checkpointPath, "utf8")) > 32_000, "the original oversized checkpoint remains recoverable");
+			assert.equal((await h.transcriptItems()).filter((entry) => entry.type === "compacted").length, 0);
+		});
+	});
+
+	for (const hintFailure of ["invalid-json", "oversize"]) {
+		test(`notes thread_hint ${hintFailure} after a successful checkpoint prevents reset`, async (t) => {
+			await usingRuntime(t, `hint-${hintFailure}-after-checkpoint`, { hintFailure }, async (h) => {
+				const turn = await h.turn(ownerRequest, [
+					{ items: [call("exec_command", { cmd: `printf '${unreadResult}\\n'`, login: false }, "hint-failure-unread")], tokens: 9_500 },
+				]);
+				assert.notEqual(turn.status, "completed");
+				assert.equal(h.requests.length, 1);
+				assert.ok(visibleFailure(h, turn), "MCP recovery failure must explain why reset was stopped");
+				const completedHooks = h.events.filter((event) => event.method === "hook/completed" && event.params.run.eventName === "preCompact");
+				assert.equal(completedHooks.length, 1);
+				assert.ok(completedHooks.every((event) => event.params.run.status === "completed"), "the checkpoint succeeded before the real MCP server encountered invalid persisted state");
+				const manifest = JSON.parse(await readFile(join(h.state, "threads", `${h.threadId}.json${hintFailure === "invalid-json" ? ".before-hint-failure" : ""}`), "utf8"));
+				const originalCheckpoint = manifest.checkpointPath + (hintFailure === "oversize" ? ".before-hint-failure" : "");
+				assert.match(await readFile(originalCheckpoint, "utf8"), /UNREAD_TOOL_RESULT_83/, "the actual production hook wrote recovery before controlled corruption");
+				const transcript = await h.transcriptItems();
+				assert.equal(transcript.filter((entry) => entry.type === "compacted").length, 0);
+				assert.match(JSON.stringify(transcript), /OWNER_REQUEST_47/);
+				assert.match(JSON.stringify(transcript), /UNREAD_TOOL_RESULT_83/);
+			});
+		});
+	}
+
+	for (const hookFailure of ["missing", "disabled", "untrusted", "unmatched", "async", "nonzero", "timeout", "malformed"]) {
+		test(`required recovery hook ${hookFailure} stops rollover with a visible failure and intact transcript`, async (t) => {
+			await usingRuntime(t, `required-hook-${hookFailure}`, { hookFailure }, async (h) => {
+				const turn = await h.turn(ownerRequest, [
+					{ items: [call("exec_command", { cmd: `printf '${unreadResult}\\n'`, login: false }, "required-hook-unread")], tokens: 9_500 },
+				]);
+				assert.notEqual(turn.status, "completed");
+				assert.equal(h.requests.length, 1, "a failed required checkpoint cannot reach a continuation request");
+				assert.ok(visibleFailure(h, turn), "required-hook failure must be visible to the client");
+				const transcript = await h.transcriptItems();
+				assert.equal(transcript.filter((entry) => entry.type === "compacted").length, 0);
+				assert.match(JSON.stringify(transcript), /OWNER_REQUEST_47/);
+				assert.match(JSON.stringify(transcript), /UNREAD_TOOL_RESULT_83/);
+				await recordAcceptance(t, h, `required-hook-${hookFailure}`, true, "Required recovery did not complete, so the window stayed intact and the client received a failure.");
+			});
+		});
+	}
+
+	for (const failureFirst of [true, false]) {
+		test(`failed sibling finishing ${failureFirst ? "before" : "after"} new_context cancels only that tool batch`, async (t) => {
+			await usingRuntime(t, `failure-${failureFirst ? "before" : "after"}-reset`, { recordToolCompletions: true }, async (h) => {
+				const failure = call("exec_command", { cmd: "printf 'ORDERED_FAILURE_31\\n' >&2; exit 7", login: false }, "ordered-failure");
+				const reset = call("new_context", {}, "ordered-reset");
+				await h.turn(ownerRequest, [
+					{ items: failureFirst ? [failure, reset] : [reset, failure], betweenItemsMs: 250 },
+					{ items: [message("handled the failed batch; start a fresh window now"), call("new_context", {}, "valid-later-reset")] },
+					{ items: [message("later valid reset completed")] },
+				]);
+				assert.equal(h.requests.length, 3);
+				assert.equal(contextWindow(h.requests[1]), contextWindow(h.requests[0]));
+				const completions = (await readFile(join(h.root, "hook-fixture.jsonl"), "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+				assert.deepEqual(completions.map((entry) => entry.tool_use_id), [...(failureFirst ? ["ordered-failure", "ordered-reset"] : ["ordered-reset", "ordered-failure"]), "valid-later-reset"], "PostToolUse timestamps prove actual completion order; transcript outputs alone are written later in call order");
+				assert.notEqual(contextWindow(h.requests[2]), contextWindow(h.requests[0]), "a handled failure must not poison a later successful tool batch within the same turn");
+				assert.equal((await h.transcriptItems()).filter((entry) => entry.type === "compacted").length, 1);
+			});
+		});
+	}
+
+	test("a canceled explicit reset at the automatic threshold shows the failure before a later reset", async (t) => {
+		await usingRuntime(t, "threshold-failed-explicit", {}, async (h) => {
+			await h.turn(ownerRequest, [
+				{ items: [call("new_context", {}, "threshold-reset"), call("exec_command", { cmd: "printf 'THRESHOLD_FAILURE_19\\n' >&2; exit 7", login: false }, "threshold-failure")], tokens: 9_500 },
+				{ items: [message("acknowledged the failure before another rollover")] },
+			]);
+			assert.equal(contextWindow(h.requests[1]), contextWindow(h.requests[0]), "automatic compaction must not silently commit the just-canceled reset before the model sees the failed batch");
+			assert.match(requestText(h.requests[1]), /THRESHOLD_FAILURE_19/);
+			assert.ok(h.requests[1].body.input.some((item) => item.type === "function_call_output" && item.call_id === "threshold-failure"), "the failed batch remains active for the immediate continuation");
+		});
+	});
+
+	test("a caught nested MCP failure cancels the advertised code-mode reset without poisoning a later retry", async (t) => {
+		await usingRuntime(t, "code-mode-caught-failure", { codeMode: true }, async (h) => {
+			const nested = [
+				'if (!ALL_TOOLS.some(tool => tool.name === "new_context")) throw new Error("new_context is missing from advertised nested tools");',
+				'const results = await Promise.allSettled([tools.new_context({}), (async () => {',
+				`const result = await tools.mcp__notes__notes({op:"read",threadId:${JSON.stringify(h.threadId)},path:"nested-missing-note.md"});`,
+				'if (result.isError) throw new Error("actual nested MCP failure");',
+				'})()]);',
+				'if (results[1].status === "rejected") text("NESTED_FAILURE_CAUGHT_71");',
+			].join("\n");
+			const turn = await h.turn(ownerRequest, [
+				{ items: [{ type: "custom_tool_call", name: "exec", namespace: "functions", call_id: "nested-caught-batch", input: nested }] },
+				{ items: [message("handled the nested failure")] },
+			]);
+			assert.equal(turn.status, "completed");
+			assert.equal(h.requests.length, 2);
+			assert.match(requestText(h.requests[1]), /NESTED_FAILURE_CAUGHT_71/);
+			assert.ok(h.events.some((event) => event.method === "item/completed" && event.params.item.type === "mcpToolCall" && event.params.item.status === "failed"));
+			assert.equal(contextWindow(h.requests[1]), contextWindow(h.requests[0]));
+			assert.equal((await h.transcriptItems()).filter((entry) => entry.type === "compacted").length, 0);
+			await h.turn("The nested failure is handled. Reset through the exposed code-mode tool now.", [
+				{ items: [{ type: "custom_tool_call", name: "exec", namespace: "functions", call_id: "nested-valid-reset", input: "text(await tools.new_context({}));" }] },
+				{ items: [message("valid nested reset completed")] },
+			]);
+			assert.notEqual(contextWindow(h.requests.at(-1)), contextWindow(h.requests[0]));
+			assert.equal((await h.transcriptItems()).filter((entry) => entry.type === "compacted").length, 1);
+		});
+	});
+
+	test("a caught malformed nested invocation cannot commit a requested reset", async (t) => {
+		await usingRuntime(t, "caught-invalid-nested-argument", { codeMode: true }, async (h) => {
+			await h.turn(ownerRequest, [
+				{ items: [{ type: "custom_tool_call", name: "exec", namespace: "functions", call_id: "invalid-argument-cell", input: 'await tools.new_context({}); try { await tools.exec_command("bad argument type"); } catch (error) { text("CAUGHT_INVALID_ARGUMENT_93"); }' }] },
+				{ items: [message("handled the rejected invocation")] },
+			]);
+			assert.equal(h.requests.length, 2);
+			assert.match(requestText(h.requests[1]), /CAUGHT_INVALID_ARGUMENT_93/);
+			assert.equal(contextWindow(h.requests[1]), contextWindow(h.requests[0]));
+			assert.equal((await h.transcriptItems()).filter((entry) => entry.type === "compacted").length, 0);
+		});
+	});
+}
 
 test("manual compaction: compare ordinary summary behavior with local token-budget mode", async (t) => {
 	let ordinarySummaryRequests;

--- a/adapters/codex-posthorse/test/store.test.mjs
+++ b/adapters/codex-posthorse/test/store.test.mjs
@@ -112,6 +112,25 @@ test("bounded checkpoints point back to complete paged originals and retain old 
 	assert.equal((await readdir(join(f.stateDir, "checkpoints", threadId))).filter((name) => name.endsWith(".json")).length, 2);
 });
 
+test("Unicode recovery fits the native byte limit without breaking characters or original history", async () => {
+	const original = "FIRST_UNICODE_REQUEST " + "漢字😀".repeat(12_000);
+	const f = await fixture([
+		user(original),
+		...Array.from({ length: 6 }, (_, index) => user(`OTHER_REQUEST_${index} ` + "漢字😀".repeat(4_000))),
+		user("LATEST_UNICODE_REQUEST " + "漢字😀".repeat(4_000)),
+		call("unicode-output"), output("unicode-output", "UNREAD_UNICODE_RESULT " + "漢字😀".repeat(4_000)),
+	]);
+	await f.store.checkpoint(f.hook);
+	const hint = await createStore(f.stateDir).threadHint(threadId);
+	assert.ok(Buffer.byteLength(hint) <= 32_000);
+	assert.ok(hint.length <= 20_000);
+	assert.ok(hint.isWellFormed());
+	for (const marker of ["FIRST_UNICODE_REQUEST", "LATEST_UNICODE_REQUEST", "UNREAD_UNICODE_RESULT"]) assert.ok(hint.includes(marker));
+	const read = await f.store.history({ threadId, op: "read", id: "ordinal:1", limit: 200_000 });
+	assert.equal(JSON.parse(read.content).payload.content[0].text, original);
+	assert.equal(await readFile(f.transcript, "utf8"), f.original);
+});
+
 test("history pages, searches, window labels, and image records survive restart exactly", async () => {
 	const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aCBkAAAAASUVORK5CYII=";
 	const image = { type: "input_image", image_url: `data:image/png;base64,${png}`, detail: "original" };


### PR DESCRIPTION
## Scope

Extend the isolated Codex Posthorse adapter to verify the companion native recovery policy. Pi's implementation and published package remain unchanged.

Companion runtime: [required checkpoint and recovery notes](https://github.com/fitchmultz/codex/pull/2), followed by [failed-tool-batch cancellation](https://github.com/fitchmultz/codex/pull/1). Consumer CI pins the complete feature commit `6c5d489f76b358ff6adedcf47211081d290b293b`.

## Changes

- Add `test:local` with strict acceptance and a discovered required checkpoint key in each isolated Codex home.
- Cover failed and unavailable required hooks, checkpoint repair/restart, real hint errors and oversized hints, initial hint loading, both tool completion orders, threshold cancellation, and caught nested failures.
- Bound the complete hint to 32,000 UTF-8 bytes while retaining the original 20,000-character cap. Unicode excerpts stay valid; complete original records remain in history.
- Add consumer CI that builds a pinned companion CLI and matching code-mode host and runs strict local acceptance. Keep the separate stock comparison.
- Document stock versus patched behavior and the remaining desktop/real-model limits.

## Verification

Local adapter tests: 14 passed. The final source-built companion CLI and matching code-mode host passed all 22 strict real-runtime scenarios with no skips or TODOs. Linux consumer CI independently built the pinned CLI/helper pair and passed 217 native hook/feature tests plus all 22 strict recovery scenarios with no skips or TODOs.

[Consumer CI](https://github.com/fitchmultz/pi-posthorse/actions/runs/34392141970) passed all seven jobs. The [initial run](https://github.com/fitchmultz/pi-posthorse/actions/runs/34392047376) stopped at workflow validation because the job-level environment could not use the runner context; the build directory is now exported by the setup step. Full-workflow actionlint passes. Both stock and patched runtime artifacts are retained with the successful run.

Pi's 39 tests and TypeScript check pass, as do all 14 adapter tests and its dependency audit. Two full native workspace runs each executed 18,195 tests: 18,153 passed / 40 failed / 2 timed out, then 18,168 passed / 9 failed / 18 timed out with an isolated environment. Both retained 48 repository-default skips. All 15 new native integration cases passed in both. Follow-up checks identified environment/dependency-cache influences and reproduced failures on unchanged upstream. The matching-feature V8 check and unchanged-baseline marketplace clone passed separately; the earlier clone timeout's exact cause remains unknown. This does not claim a clean native workspace suite.

Native runner totals include existing tests that can return early for missing helpers, beyond the reported 48 skips. With the missing helper and verified cache present, all 17 affected zsh cases genuinely ran on unchanged upstream: 15 passed and 2 failed. All five POSIX/core shell failures also reproduced twice on unchanged upstream. This caveat does not apply to the adapter's 22 strict real-runtime scenarios, which completed without skips or TODOs.

All runtime requests, events, transcripts, and acceptance receipts remain in the test cache. No normal Codex configuration, account credentials, or desktop runtime was changed. No real model inference or 500,000-token workload is claimed.
