### PR TITLE
Fix stock Codex recovery after missed checkpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,18 @@ jobs:
           curl --fail --location --retry 2 https://github.com/openai/codex/releases/download/rust-v0.153.4/codex-x86_64-unknown-linux-musl.tar.gz -o "$RUNNER_TEMP/codex-runtime.tar.gz"
           mkdir -p "$RUNNER_TEMP/codex-runtime"
           tar -xzf "$RUNNER_TEMP/codex-runtime.tar.gz" -C "$RUNNER_TEMP/codex-runtime"
+          curl --fail --location --retry 2 https://github.com/openai/codex/releases/download/rust-v0.153.4/codex-code-mode-host-x86_64-unknown-linux-musl.tar.gz -o "$RUNNER_TEMP/codex-code-mode-host.tar.gz"
+          tar -xzf "$RUNNER_TEMP/codex-code-mode-host.tar.gz" -C "$RUNNER_TEMP/codex-runtime"
+          mv "$RUNNER_TEMP/codex-runtime/codex-code-mode-host-x86_64-unknown-linux-musl" "$RUNNER_TEMP/codex-runtime/codex-code-mode-host"
           "$RUNNER_TEMP/codex-runtime/codex-x86_64-unknown-linux-musl" --version
       - name: Characterize real runtime behavior
         env:
           POSTHORSE_CODEX_BIN: ${{ runner.temp }}/codex-runtime/codex-x86_64-unknown-linux-musl
         run: npm run test:runtime
+      - name: Verify ordinary compaction with stock recovery hooks
+        env:
+          POSTHORSE_CODEX_BIN: ${{ runner.temp }}/codex-runtime/codex-x86_64-unknown-linux-musl
+        run: npm run test:stock
       - name: Save runtime evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/adapters/codex-posthorse/README.md
+++ b/adapters/codex-posthorse/README.md
@@ -1,8 +1,8 @@
 # Codex Posthorse prototype
 
-An isolated proof of Posthorse-style context recovery using Codex's existing local context-reset path, a local tool server, and hooks. It does not replace Pi Posthorse, change the Pi package, or enable Codex's account-gated remote context-management service.
+An isolated proof of Posthorse-style context recovery using Codex's local tool server and hooks. It supports ordinary compaction on the official runtime and the companion fork's no-summary reset. It does not replace Pi Posthorse, change the Pi package, or enable Codex's account-gated remote context-management service.
 
-**Isolated testing only.** The companion local-recovery runtime patch passes the controlled recovery checks. Stock Codex does not meet all of them, and installed desktop behavior and real-model workloads have not been validated. Nothing here installs itself, changes your normal Codex configuration, or replaces the desktop runtime.
+**Isolated testing only.** The companion local-recovery runtime patch passes the controlled recovery checks. The [stock hook approach](stock-hooks.md) preserves ordinary summaries and repairs missed checkpoints from original history, but does not supply the fork's required-hook guarantees. Recovery and native task-listing calls coexisted in a user-operated signed-stock desktop trial; real-model workloads and every desktop integration have not been validated. Nothing here installs itself, changes your normal Codex configuration, or replaces the desktop runtime.
 
 ## What has been proved
 
@@ -20,7 +20,7 @@ Tests run the actual app-server, command tools, hooks, local MCP server, and mat
 
 The strict local suite has 22 passing scenarios. It also covers caught nested errors and malformed nested arguments through advertised code-mode tools, later successful reset after a handled failure, and oversized saved hints on initial context loading. Adapter tests cover Unicode byte limits and exact original-history recovery.
 
-The fixture selects the `gpt-6-astra` model identifier. This proves runtime wiring, not Astra's behavior, a 500,000-token workload, or usability inside the desktop app. The tests use a 50,000-token configured window and synthetic usage crossing a 9,000-token threshold to make rollover reproducible.
+The fixture selects the `gpt-6-astra` model identifier. This proves runtime wiring, not Astra's behavior or a 500,000-token workload. The tests use a 50,000-token configured window and synthetic usage crossing a 9,000-token threshold to make rollover reproducible. The table compares token-budget modes; ordinary stock compaction is tested separately with `test:stock`.
 
 ## How recovery works
 
@@ -45,12 +45,13 @@ The tool server does not make network requests. Returned notes and history becom
 
 ## Run the isolated tests
 
-Requirements: Node `>=22.19.0`, stock Codex `0.153.4` for the pinned comparison, or the companion patched CLI and matching code-mode host for local acceptance. From this directory:
+Requirements: Node `>=22.19.0`, stock Codex `0.153.4` and its matching code-mode host for stock tests, or the companion patched CLI and matching host for local acceptance. From this directory:
 
 ```bash
 npm ci --ignore-scripts
 npm test
 npm run test:runtime
+npm run test:stock
 npm run test:acceptance
 ```
 

--- a/adapters/codex-posthorse/package.json
+++ b/adapters/codex-posthorse/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "node --test test/store.test.mjs test/server.test.mjs",
     "test:runtime": "node --test test/runtime.test.mjs",
+    "test:stock": "node --test test/stock-runtime.test.mjs test/stock-v2.test.mjs",
     "test:acceptance": "POSTHORSE_ACCEPTANCE=1 node --test test/runtime.test.mjs",
     "test:local": "POSTHORSE_LOCAL_RECOVERY=1 POSTHORSE_ACCEPTANCE=1 node --test test/runtime.test.mjs"
   },

--- a/adapters/codex-posthorse/scripts/stock-session-start.mjs
+++ b/adapters/codex-posthorse/scripts/stock-session-start.mjs
@@ -1,0 +1,15 @@
+import { createStore } from "../store.mjs";
+
+try {
+	let raw = "";
+	for await (const chunk of process.stdin) raw += chunk;
+	const input = JSON.parse(raw);
+	const hint = await createStore(process.env.POSTHORSE_STATE_DIR).stockHint(input);
+	const additionalContext = `Posthorse recovery from SessionStart source=${input.source}. This supplements ordinary compaction; it does not replace the summary.\n\n${hint}`;
+	if (Buffer.byteLength(additionalContext) > 32_000) throw new Error("Recovery hint exceeds 32,000 bytes.");
+	process.stdout.write(`${JSON.stringify({
+		continue: true, hookSpecificOutput: { hookEventName: "SessionStart", additionalContext },
+	})}\n`);
+} catch (error) {
+	process.stdout.write(`${JSON.stringify({ continue: false, stopReason: `Posthorse recovery hook failed: ${error.message}` })}\n`);
+}

--- a/adapters/codex-posthorse/stock-hooks.md
+++ b/adapters/codex-posthorse/stock-hooks.md
@@ -1,0 +1,29 @@
+# Ordinary compaction with stock recovery hooks
+
+This opt-in path keeps the official Codex runtime and ordinary summarization. A `PreCompact` hook saves recovery notes before summarization. `scripts/stock-session-start.mjs` rebuilds those notes from the original transcript after compaction and on resume, then supplies them as additional developer context. It does not trust an older checkpoint merely because one exists.
+
+Reconstruction uses the records immediately before the latest saved compaction boundary. Normal assistant-message and plan completion events identify consumed tool batches; raw summarizer messages do not. This distinction matters because ordinary Codex records its summary as assistant text before saving the boundary. Several summary messages, missing token-usage metadata, and older line-based transcripts are covered by tests. The existing bounded excerpts, original record IDs, notes, and history tools are reused; original transcripts and older checkpoints are not changed.
+
+## Isolated configuration
+
+Keep `features.token_budget.enabled` and `features.context_management` false. In a separate test home, configure the existing `scripts/precompact.mjs` as `PreCompact` and the new `scripts/stock-session-start.mjs` as `SessionStart` without a matcher, so startup, resume, and compact events are covered. Use absolute script paths and set `additionalContextLimit = 10000` on the SessionStart command hook. Trust those exact hooks through Codex's normal hook-trust controls.
+
+Set `POSTHORSE_STATE_DIR` explicitly for the hook process and the existing direct `notes` MCP server. The stock hook requires it; it will not silently write into the everyday home. Keep the ordinary `scripts/session-start.mjs` for the native-fork mode and child registration. Do not enable `local_recovery_hook` or replace the signed executable for this path.
+
+No installer or plugin activation is included. The existing plugin scaffold still selects the native-fork hooks. Read the [official hook documentation](https://learn.chatgpt.com/docs/hooks#sessionstart) for event timing and configuration. Transcript JSONL is not a stable hook interface, so compatibility must be rechecked after runtime updates.
+
+## Failure behavior
+
+A missing, disabled, crashed, timed-out, or malformed-output PreCompact hook does not necessarily stop stock Codex from summarizing. The restoration hook repairs a missed checkpoint from retained originals before the next model request, including when an older valid checkpoint exists. Recovery does not require the user to rerun the completed tool.
+
+A handled checkpoint-write failure still returns `continue: false` before summarization. If reconstruction itself cannot read valid original records, find a required compaction boundary, or save its result, it returns `continue: false` instead of supplying stale notes. Repair the underlying file or permission problem and resume the same task; the original transcript and previous checkpoints are retained.
+
+Stock Codex does not enforce a required restoration hook: if that process itself crashes, is disabled, or never starts, these scripts cannot guarantee that continuation stops. This is not the fork's stronger pre-reset checkpoint contract. Tool-result consumption remains an explicitly labeled inference, not exact model acknowledgement.
+
+## Verification
+
+Run `POSTHORSE_CODEX_BIN=/absolute/path/to/codex npm run test:stock` from this directory. Use the matching official code-mode host beside the CLI. The suite uses the real runtime with scripted loopback responses and no account credentials.
+
+Coverage includes ordinary automatic and manual summaries, immediate recovery, repeated compaction after a checkpoint crash, runtime restart, code mode, durable notes, exact original-history retrieval, and the newer V2 compaction client path. Store tests cover normal and legacy completion events and rejection of malformed originals without replacing a prior valid checkpoint.
+
+An earlier signed-stock desktop trial proved native task-listing calls before and after compaction and after a real app restart. The repaired hook has separate runtime regression coverage; that earlier UI trial is not a fresh desktop test of this revision. Real Astra responses, a 500,000-token workload, every native desktop feature, and real subagent rollover remain unverified. Everyday installation is a separate step.

--- a/adapters/codex-posthorse/store.mjs
+++ b/adapters/codex-posthorse/store.mjs
@@ -184,7 +184,8 @@ function hintGuidance(threadId) {
 	].join("\n\n");
 }
 
-async function recoveryFrom(file, threadId, rootThreadId) {
+async function recoveryFrom(file, threadId, rootThreadId, source) {
+	const stockRecovery = source === "compact" || source === "resume";
 	const ownerEvents = [];
 	const userItems = [];
 	let calls = new Map();
@@ -193,22 +194,34 @@ async function recoveryFrom(file, threadId, rootThreadId) {
 	let last;
 	let sessionId;
 	let boundary;
+	let beforeCompaction;
 	for await (const record of transcriptRecords(file)) {
-		last = record;
 		const { row } = record;
 		const payload = row.payload ?? {};
 		if (row.type === "session_meta") sessionId = payload.id ?? payload.session_id;
 		if (row.type === "compacted") {
+			if (stockRecovery) beforeCompaction = {
+				ownerCount: ownerEvents.length, userCount: userItems.length,
+				calls, outputs, last, boundary, compactionId: record.id,
+			};
 			boundary = record;
 			calls = new Map();
 			outputs = [];
 			responseEnded = false;
 		}
+		last = record;
 		if (row.type === "event_msg" && payload.type === "user_message") ownerEvents.push(record);
 		if (row.type === "event_msg" && payload.type === "token_count") responseEnded = true;
+		// Stock summaries persist raw assistant messages but no normal completion event.
+		if (stockRecovery && row.type === "event_msg" && (payload.type === "agent_message"
+			|| (payload.type === "item_completed" && ["AgentMessage", "Plan"].includes(payload.item?.type)))) {
+			calls = new Map();
+			outputs = [];
+			responseEnded = false;
+		}
 		if (row.type !== "response_item") continue;
 		if (payload.type === "message" && payload.role === "user") userItems.push(record);
-		const assistantOutput = TOOL_CALLS.has(payload.type) || (payload.type === "message" && payload.role === "assistant");
+		const assistantOutput = TOOL_CALLS.has(payload.type) || (!stockRecovery && payload.type === "message" && payload.role === "assistant");
 		if (assistantOutput && payload.status !== "failed" && payload.status !== "incomplete") {
 			if (responseEnded || (payload.type === "message" && outputs.length)) {
 				calls = new Map();
@@ -218,6 +231,12 @@ async function recoveryFrom(file, threadId, rootThreadId) {
 		}
 		if (TOOL_CALLS.has(payload.type)) calls.set(payload.call_id ?? payload.id, record);
 		if (TOOL_OUTPUTS.has(payload.type)) outputs.push(record);
+	}
+	if (source === "compact" && !beforeCompaction) throw new Error("No completed compaction boundary found; recovery cannot be confirmed.");
+	if (beforeCompaction) {
+		ownerEvents.length = beforeCompaction.ownerCount;
+		userItems.length = beforeCompaction.userCount;
+		({ calls, outputs, last, boundary } = beforeCompaction);
 	}
 	if (!last) throw new Error("Cannot checkpoint an empty transcript.");
 	if (sessionId && sessionId !== threadId) throw new Error("Transcript session ID does not match threadId.");
@@ -269,6 +288,7 @@ async function recoveryFrom(file, threadId, rootThreadId) {
 	}
 	return {
 		throughId: last.id, throughLine: last.line, throughOrdinal: last.ordinal, windowId: last.windowId,
+		...(beforeCompaction ? { compactionId: beforeCompaction.compactionId } : {}),
 		recovery,
 	};
 }
@@ -322,14 +342,15 @@ export function createStore(stateDir) {
 		await atomicWrite(manifestPath(threadId), JSON.stringify(manifest, null, 2));
 		return manifest;
 	}
-	async function checkpoint(input) {
+	async function checkpoint(input, source) {
 		const threadId = threadKey(input.agent_id ?? input.session_id ?? input.threadId);
 		const rootThreadId = input.session_id ?? threadId;
 		const transcriptPath = resolve(required(input.transcript_path ?? input.transcriptPath, "transcript_path"));
-		const recovery = await recoveryFrom(transcriptPath, threadId, rootThreadId);
+		const recovery = await recoveryFrom(transcriptPath, threadId, rootThreadId, source);
 		const checkpoint = {
 			version: 1, id: randomUUID(), threadId, rootThreadId, transcriptPath, turnId: input.turn_id,
 			trigger: input.trigger, createdAt: new Date().toISOString(), ...recovery,
+			...(source ? { source } : {}),
 		};
 		const checkpointPath = join(root, "checkpoints", threadId, `${checkpoint.id}.json`);
 		await atomicWrite(checkpointPath, JSON.stringify(checkpoint, null, 2));
@@ -345,6 +366,11 @@ export function createStore(stateDir) {
 			checkpoint?.recovery,
 			hintGuidance(threadId),
 		].filter(Boolean).join("\n\n");
+	}
+	async function stockHint(input) {
+		const manifest = input.source === "compact" || input.source === "resume"
+			? await checkpoint(input, input.source) : await register(input);
+		return threadHint(manifest.threadId);
 	}
 	async function notes(params) {
 		const root = notesRoot(params.threadId);
@@ -419,5 +445,5 @@ export function createStore(stateDir) {
 		if (op === "read") throw new Error(`History record not found: ${params.id}`);
 		return { items, offset, total, nextOffset: offset + items.length < total ? offset + items.length : null };
 	}
-	return { register, checkpoint, threadHint, notes, history };
+	return { register, checkpoint, threadHint, stockHint, notes, history };
 }

--- a/adapters/codex-posthorse/test/runtime-harness.mjs
+++ b/adapters/codex-posthorse/test/runtime-harness.mjs
@@ -35,7 +35,7 @@ export function contextWindow(request) {
 export class RuntimeHarness {
 	static async create(name, {
 		tokenBudget = true, failCheckpoint = false, hookFailure, hintFailure, recordToolCompletions = false,
-		localRecovery = process.env.POSTHORSE_LOCAL_RECOVERY === "1", codeMode = false,
+		localRecovery = process.env.POSTHORSE_LOCAL_RECOVERY === "1", codeMode = false, stockRecovery = false,
 	} = {}) {
 		const cache = join(homedir(), "Library", "Caches", "pi-runs");
 		await mkdir(cache, { recursive: true });
@@ -48,6 +48,7 @@ export class RuntimeHarness {
 		harness.hintFailure = hintFailure;
 		harness.recordToolCompletions = recordToolCompletions;
 		harness.codeMode = codeMode;
+		harness.stockRecovery = stockRecovery;
 		try {
 			await harness.initialize();
 			return harness;
@@ -79,7 +80,7 @@ export class RuntimeHarness {
 				const chunks = [];
 				for await (const chunk of req) chunks.push(chunk);
 				const raw = Buffer.concat(chunks).toString();
-				const request = { path: req.url, body: raw ? JSON.parse(raw) : null };
+				const request = { recordedAt: Date.now(), path: req.url, body: raw ? JSON.parse(raw) : null };
 				this.requests.push(request);
 				await appendFile(join(this.root, "model-requests.jsonl"), `${JSON.stringify(request)}\n`);
 				if (this.failCheckpoint && this.requests.length === 1) {
@@ -114,10 +115,10 @@ export class RuntimeHarness {
 		});
 		this.server.listen(0, "127.0.0.1");
 		await once(this.server, "listening");
-		const hookCommand = this.hintFailure || ["nonzero", "timeout", "malformed"].includes(this.hookFailure)
+		const hookCommand = this.hintFailure || ["nonzero", "timeout", "malformed", "crash-after-checkpoint"].includes(this.hookFailure)
 			? `${shellQuote(process.execPath)} ${shellQuote(fileURLToPath(import.meta.url))} --hook-fixture ${this.hintFailure ? `checkpoint-then-${this.hintFailure}-hint` : this.hookFailure}`
 			: `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "precompact.mjs"))}`;
-		const sessionCommand = `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", "session-start.mjs"))}`;
+		const sessionCommand = `${shellQuote(process.execPath)} ${shellQuote(join(adapter, "scripts", this.stockRecovery ? "stock-session-start.mjs" : "session-start.mjs"))}`;
 		const completionCommand = `${shellQuote(process.execPath)} ${shellQuote(fileURLToPath(import.meta.url))} --hook-fixture record-completion`;
 		const preCompactConfig = [
 			'[[hooks.PreCompact]]',
@@ -131,6 +132,7 @@ export class RuntimeHarness {
 			'model_context_window = 50000', 'model_auto_compact_token_limit = 9000',
 			'approval_policy = "never"', 'sandbox_mode = "danger-full-access"',
 			'web_search = "disabled"',
+			...(this.stockRecovery ? [`sqlite_home = ${quote(join(this.home, "sqlite"))}`] : []),
 			'[features]', 'context_management = false', 'apps = false', 'remote_plugin = false',
 			'memories = false', 'multi_agent = false', 'shell_snapshot = false', 'hooks = true',
 			`code_mode_host = ${this.codeMode}`,
@@ -146,6 +148,7 @@ export class RuntimeHarness {
 			preCompactConfig.trimEnd(),
 			'[[hooks.SessionStart]]',
 			'[[hooks.SessionStart.hooks]]', 'type = "command"', `command = ${quote(sessionCommand)}`,
+			...(this.stockRecovery ? ['additional_context_limit = 10000'] : []),
 			...(this.recordToolCompletions ? ['[[hooks.PostToolUse]]', '[[hooks.PostToolUse.hooks]]', 'type = "command"', `command = ${quote(completionCommand)}`] : []),
 			`[projects.${quote(this.cwd)}]`, 'trust_level = "trusted"',
 		].join("\n") + "\n";
@@ -203,6 +206,7 @@ export class RuntimeHarness {
 					else pending.resolve(event.result);
 				}
 			} else {
+				if (this.stockRecovery) event.recordedAt = Date.now();
 				this.events.push(event);
 				for (const waiter of [...this.waiters]) if (waiter.predicate(event)) {
 					clearTimeout(waiter.timer);
@@ -321,6 +325,20 @@ if (process.argv[2] === "--hook-fixture") {
 		case "timeout":
 			await delay(10_000);
 			break;
+		case "crash-after-checkpoint": {
+			const marker = join(dirname(process.env.CODEX_HOME), "checkpoint-succeeded-once");
+			const succeededBefore = await readFile(marker, "utf8").catch((error) => { if (error.code === "ENOENT") return false; throw error; });
+			if (succeededBefore) {
+				process.stderr.write("CONTROLLED_SECOND_CHECKPOINT_PROCESS_FAILURE\n");
+				process.exitCode = 7;
+			} else {
+				const checkpoint = spawnSync(process.execPath, [join(adapter, "scripts", "precompact.mjs")], { input, encoding: "utf8" });
+				if (checkpoint.status !== 0 || JSON.parse(checkpoint.stdout).continue !== true) throw new Error(`Production checkpoint failed: ${checkpoint.stderr} ${checkpoint.stdout}`);
+				await writeFile(marker, "First real checkpoint succeeded.\n");
+				process.stdout.write(checkpoint.stdout);
+			}
+			break;
+		}
 		case "checkpoint-then-invalid-json-hint":
 		case "checkpoint-then-oversize-hint": {
 			const checkpoint = spawnSync(process.execPath, [join(adapter, "scripts", "precompact.mjs")], { input, encoding: "utf8" });

--- a/adapters/codex-posthorse/test/stock-runtime.test.mjs
+++ b/adapters/codex-posthorse/test/stock-runtime.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { RuntimeHarness, call, message, requestText, discoverNotes } from "./runtime-harness.mjs";
+
+const owner = "StockHooksOwner47: preserve my exact request and the unread result through ordinary compaction.";
+const unread = "STOCK_UNREAD_RESULT_83";
+const lossy = "LOSSY_SUMMARY_21: Continue the existing task. Original request and tool-result markers are deliberately omitted.";
+
+async function usingRuntime(t, name, options, run) {
+	const h = await RuntimeHarness.create(`stock-hooks-${name}`, { tokenBudget: false, localRecovery: false, stockRecovery: true, ...options });
+	t.diagnostic(`Retained real-runtime artifacts: ${h.root}`);
+	try {
+		assert.match(h.config, /context_management = false/);
+		assert.match(h.config, /\[features.token_budget\]\nenabled = false/);
+		assert.doesNotMatch(h.config, /local_recovery_hook/);
+		const account = await h.rpc("account/read", {});
+		assert.equal(account.requiresOpenaiAuth, false);
+		await h.thread();
+		await run(h);
+	} finally { await h.close(); }
+}
+
+async function receipt(h, name, facts) {
+	await writeFile(join(h.root, "acceptance.json"), JSON.stringify({
+		name, passed: true, runtime: process.env.POSTHORSE_CODEX_BIN ?? "codex",
+		threadId: h.threadId, transcript: h.transcript, ...facts,
+	}, null, 2) + "\n");
+}
+
+function automaticReplies({ codeMode = false, marker = unread, callId = "unread-shell", summary = lossy } = {}) {
+	const args = { cmd: `printf '${marker}\\n'`, login: false };
+	return [
+		{ items: [codeMode ? { type: "custom_tool_call", name: "exec", namespace: "functions", call_id: callId, input: `text(await tools.exec_command(${JSON.stringify(args)}));` } : call("exec_command", args, callId)], tokens: 9500 },
+		{ items: [message(summary)] },
+		{ items: [message("ordinary recovery complete")] },
+	];
+}
+
+function sourceContext(request, source) {
+	return request.body.input.filter((item) => item.type === "message" && item.role === "developer" && JSON.stringify(item).includes(`source=${source}`));
+}
+
+function assertRecovery(h, requestIndex, source, markers) {
+	const request = h.requests[requestIndex];
+	const context = sourceContext(request, source);
+	assert.equal(context.length, 1, `one ${source} hook must supply recovery before the next model request`);
+	for (const marker of markers) assert.ok(JSON.stringify(context).includes(marker), `${source} recovery must include ${marker}`);
+	const hook = h.events.findLast((event) => event.method === "hook/completed" && event.params.run.eventName === "sessionStart" && event.recordedAt <= request.recordedAt && event.params.run.entries.some((entry) => entry.kind === "context" && entry.text.includes(`source=${source}`)));
+	assert.ok(hook, "the real runtime must report the recovery hook output");
+	assert.equal(hook.params.run.status, "completed");
+	for (const marker of markers) assert.ok(JSON.stringify(hook.params.run.entries).includes(marker));
+	return hook;
+}
+
+async function savedCheckpoint(h) {
+	const manifest = JSON.parse(await readFile(join(h.state, "threads", `${h.threadId}.json`), "utf8"));
+	return { path: manifest.checkpointPath, ...JSON.parse(await readFile(manifest.checkpointPath, "utf8")) };
+}
+
+for (const codeMode of [false, true]) {
+	test(`ordinary compaction restores unread output, survives restart, and preserves manual summaries (code mode ${codeMode})`, async (t) => {
+		await usingRuntime(t, `auto-restart-manual-${codeMode}`, { codeMode }, async (h) => {
+			const turn = await h.turn(owner, automaticReplies({ codeMode }));
+			assert.equal(turn.status, "completed");
+			assert.equal(h.requests.length, 3, "normal request, real summarization, then immediate continuation");
+			assert.match(requestText(h.requests[1]), /StockHooksOwner47/);
+			assert.match(requestText(h.requests[1]), /STOCK_UNREAD_RESULT_83/);
+			assert.match(requestText(h.requests[2]), /LOSSY_SUMMARY_21/);
+			assert.ok(!h.requests[2].body.input.some((item) => ["function_call_output", "custom_tool_call_output"].includes(item.type) && item.call_id === "unread-shell"));
+			const hook = assertRecovery(h, 2, "compact", ["StockHooksOwner47", unread]);
+			assert.ok(hook.recordedAt >= h.requests[1].recordedAt, "recovery hook runs after summarization begins");
+			const checkpoint = await savedCheckpoint(h);
+			assert.ok(Date.parse(checkpoint.createdAt) <= h.requests[2].recordedAt);
+			assert.match(checkpoint.recovery, /StockHooksOwner47/);
+			assert.match(checkpoint.recovery, /STOCK_UNREAD_RESULT_83/);
+			const checkpointDir = join(h.state, "checkpoints", h.threadId);
+			const checkpoints = await Promise.all((await readdir(checkpointDir)).map(async (name) => JSON.parse(await readFile(join(checkpointDir, name), "utf8"))));
+			assert.ok(checkpoints.some((entry) => Date.parse(entry.createdAt) <= h.requests[1].recordedAt && entry.recovery.includes(unread)), "PreCompact preserves originals before the summary request");
+			const transcript = await h.transcriptItems();
+			const compactions = transcript.filter((row) => row.type === "compacted");
+			assert.equal(compactions.length, 1);
+			assert.match(compactions[0].payload.message, /LOSSY_SUMMARY_21/);
+			assert.doesNotMatch(compactions[0].payload.message, /StockHooksOwner47|STOCK_UNREAD_RESULT_83/);
+			const originalIndex = transcript.findIndex((row) => row.type === "response_item" && ["function_call_output", "custom_tool_call_output"].includes(row.payload.type) && row.payload.call_id === "unread-shell");
+			assert.ok(originalIndex >= 0);
+			const original = transcript[originalIndex];
+			const originalId = Number.isSafeInteger(original.ordinal) ? `ordinal:${original.ordinal}` : `line:${originalIndex + 1}`;
+			await h.turn("Save the durable handoff note.", [
+				{ items: [discoverNotes()] },
+				{ items: [call("notes", { op: "write", threadId: h.threadId, path: "handoff.md", content: "STOCK_DURABLE_NOTE_14: continue the ordinary compaction proof." }, "write-note", "mcp__notes")] },
+				{ items: [message("note saved")] },
+			]);
+			assert.match(JSON.stringify(h.requests.at(-1).body.input.find((item) => item.call_id === "write-note" && item.type === "function_call_output")), /writtenChars/);
+			const launches = h.launches;
+			await h.restart();
+			const resumeFrom = h.requests.length;
+			await h.turn("Continue after the full app-server restart.", [
+				{ items: [discoverNotes()] },
+				{ items: [
+					call("notes", { op: "read", threadId: h.threadId, path: "handoff.md" }, "read-note", "mcp__notes"),
+					call("history", { op: "read", threadId: h.threadId, id: originalId }, "read-original", "mcp__notes"),
+				] },
+				{ items: [message("restart proof complete")] },
+			]);
+			assert.equal(h.launches, launches + 1);
+			assertRecovery(h, resumeFrom, "resume", ["StockHooksOwner47", unread]);
+			const finalInput = h.requests.at(-1).body.input;
+			assert.match(JSON.stringify(finalInput.find((item) => item.call_id === "read-note" && item.type === "function_call_output")), /STOCK_DURABLE_NOTE_14/);
+			assert.match(JSON.stringify(finalInput.find((item) => item.call_id === "read-original" && item.type === "function_call_output")), /STOCK_UNREAD_RESULT_83/);
+			const manualFrom = h.requests.length;
+			await h.compact([{ items: [message("MANUAL_STOCK_SUMMARY_61: the same work continues.")] }]);
+			assert.equal(h.requests.length, manualFrom + 1, "manual compaction summarizes exactly once");
+			const manualRows = (await h.transcriptItems()).filter((row) => row.type === "compacted");
+			assert.equal(manualRows.length, 2);
+			assert.match(manualRows[1].payload.message, /MANUAL_STOCK_SUMMARY_61/);
+			await h.turn("Continue after manual compaction.", [{ items: [message("manual continuation finished")] }]);
+			assert.match(requestText(h.requests.at(-1)), /MANUAL_STOCK_SUMMARY_61/);
+			assertRecovery(h, h.requests.length - 1, "compact", ["StockHooksOwner47"]);
+			await receipt(h, "ordinary-automatic-restart-manual", { codeMode, automaticCompactions: 1, fullAppServerRestart: true, durableNoteRead: true, originalToolHistoryRead: true, manualCompactions: 1 });
+		});
+	});
+}
+
+test("handled checkpoint write failure stops before ordinary summarization and retains originals", async (t) => {
+	await usingRuntime(t, "handled-write-failure", { failCheckpoint: true }, async (h) => {
+		await h.turn(owner, [automaticReplies()[0]]);
+		assert.equal(h.requests.length, 1);
+		const transcript = await h.transcriptItems();
+		assert.equal(transcript.filter((row) => row.type === "compacted").length, 0);
+		assert.match(JSON.stringify(transcript), /StockHooksOwner47/);
+		assert.match(JSON.stringify(transcript), /STOCK_UNREAD_RESULT_83/);
+		const stoppedHook = h.events.find((event) => event.method === "hook/completed" && event.params.run.eventName === "preCompact" && event.params.run.status === "stopped");
+		assert.ok(stoppedHook, "continue:false must be visible as a stopped hook");
+		assert.match(JSON.stringify(stoppedHook), /could not save recovery state/);
+		await receipt(h, "handled-checkpoint-write-failure", { modelRequests: 1, compactions: 0, originalsPreserved: true });
+	});
+});
+
+for (const hookFailure of ["nonzero", "disabled", "malformed", "timeout"]) {
+	test(`ordinary recovery reconstructs originals after a ${hookFailure} PreCompact hook`, async (t) => {
+		await usingRuntime(t, `recover-${hookFailure}`, { hookFailure }, async (h) => {
+			const turn = await h.turn(owner, automaticReplies());
+			assert.equal(turn.status, "completed");
+			assert.equal(h.requests.length, 3);
+			assertRecovery(h, 2, "compact", ["StockHooksOwner47", unread]);
+			const checkpoint = await savedCheckpoint(h);
+			assert.ok(Date.parse(checkpoint.createdAt) >= h.requests[1].recordedAt, "replacement checkpoint is made after the summary request");
+			assert.ok(Date.parse(checkpoint.createdAt) <= h.requests[2].recordedAt);
+			assert.match(checkpoint.recovery, /STOCK_UNREAD_RESULT_83/);
+			const transcript = await h.transcriptItems();
+			assert.equal(transcript.filter((row) => row.type === "compacted").length, 1);
+			assert.match(JSON.stringify(transcript), /STOCK_UNREAD_RESULT_83/);
+			const precompact = h.events.filter((event) => event.method === "hook/completed" && event.params.run.eventName === "preCompact");
+			if (hookFailure === "disabled") assert.equal(precompact.length, 0);
+			else assert.ok(precompact.some((event) => event.params.run.status === "failed"));
+			assert.ok(!h.events.some((event) => event.method === "hook/completed" && event.params.run.eventName === "sessionStart" && event.params.run.status === "stopped"));
+			await receipt(h, `recovered-${hookFailure}-checkpoint`, { compactions: 1, immediateOriginalRecovery: true, replacementCheckpoint: checkpoint.path });
+		});
+	});
+}
+
+test("a later hook crash refreshes the stale checkpoint with the newest unread result", async (t) => {
+	await usingRuntime(t, "later-hook-crash", { hookFailure: "crash-after-checkpoint" }, async (h) => {
+		assert.equal((await h.turn(owner, automaticReplies())).status, "completed");
+		assertRecovery(h, 2, "compact", ["StockHooksOwner47", unread]);
+		const firstCheckpoint = await savedCheckpoint(h);
+		const secondFrom = h.requests.length;
+		const newest = "STOCK_SECOND_UNREAD_RESULT_96";
+		const second = await h.turn("StockSecondOwnerRequest96: preserve this later output too.", automaticReplies({ marker: newest, callId: "second-unread-shell", summary: "SECOND_LOSSY_SUMMARY_82: Keep working on the existing task." }));
+		assert.equal(second.status, "completed");
+		assert.equal(h.requests.length, secondFrom + 3);
+		assert.match(requestText(h.requests[secondFrom + 1]), /STOCK_SECOND_UNREAD_RESULT_96/);
+		assertRecovery(h, secondFrom + 2, "compact", ["StockSecondOwnerRequest96", newest]);
+		assert.ok(!h.requests[secondFrom + 2].body.input.some((item) => item.call_id === "second-unread-shell" && item.type === "function_call_output"));
+		const latest = await savedCheckpoint(h);
+		assert.notEqual(latest.path, firstCheckpoint.path);
+		assert.match(latest.recovery, /STOCK_SECOND_UNREAD_RESULT_96/);
+		assert.ok(Date.parse(latest.createdAt) >= h.requests[secondFrom + 1].recordedAt);
+		const transcript = await h.transcriptItems();
+		assert.equal(transcript.filter((row) => row.type === "compacted").length, 2);
+		assert.match(JSON.stringify(transcript), /STOCK_SECOND_UNREAD_RESULT_96/);
+		const originalIndex = transcript.findIndex((row) => row.type === "response_item" && row.payload.type === "function_call_output" && row.payload.call_id === "second-unread-shell");
+		assert.ok(originalIndex >= 0);
+		const original = transcript[originalIndex];
+		const originalId = Number.isSafeInteger(original.ordinal) ? `ordinal:${original.ordinal}` : `line:${originalIndex + 1}`;
+		assert.ok(h.events.some((event) => event.method === "hook/completed" && event.params.run.eventName === "preCompact" && event.params.run.status === "failed"));
+		const launches = h.launches;
+		await h.restart();
+		await h.turn("Continue after restarting the recovered task.", [{ items: [message("restarted after recovery")] }]);
+		assert.equal(h.launches, launches + 1);
+		assertRecovery(h, h.requests.length - 1, "resume", ["StockSecondOwnerRequest96", newest]);
+		const manualFrom = h.requests.length;
+		await h.compact([{ items: [message("MANUAL_AFTER_CRASH_SUMMARY_32: Continue the same task.")] }]);
+		assert.equal(h.requests.length, manualFrom + 1);
+		const manualContinuation = h.requests.length;
+		await h.turn("Read the original result after manual compaction of the recovered task.", [
+			{ items: [discoverNotes()] },
+			{ items: [call("history", { op: "read", threadId: h.threadId, id: originalId }, "read-latest-original", "mcp__notes")] },
+			{ items: [message("manual recovery complete")] },
+		]);
+		assertRecovery(h, manualContinuation, "compact", ["StockSecondOwnerRequest96"]);
+		assert.match(requestText(h.requests[manualContinuation]), /MANUAL_AFTER_CRASH_SUMMARY_32/);
+		assert.match(JSON.stringify(h.requests.at(-1).body.input.find((item) => item.call_id === "read-latest-original" && item.type === "function_call_output")), /STOCK_SECOND_UNREAD_RESULT_96/);
+		assert.equal((await h.transcriptItems()).filter((row) => row.type === "compacted").length, 3);
+		await receipt(h, "later-hook-crash-recovered", { newestResultRecovered: true, previousCheckpoint: firstCheckpoint.path, refreshedCheckpoint: latest.path, fullAppServerRestart: true, manualSummaryPreserved: true, originalsPreserved: true });
+	});
+});
+
+test("multiple summarizer messages do not mark the original trailing tool result as consumed", async (t) => {
+	await usingRuntime(t, "multi-message-summary", { hookFailure: "nonzero" }, async (h) => {
+		const replies = automaticReplies();
+		replies[1].items = [message("SUMMARY_PART_ONE: Continue this task."), message("SUMMARY_PART_TWO: Specific original records are omitted.")];
+		assert.equal((await h.turn(owner, replies)).status, "completed");
+		assert.equal(h.requests.length, 3);
+		assertRecovery(h, 2, "compact", ["StockHooksOwner47", unread]);
+		assert.ok(!h.requests[2].body.input.some((item) => item.call_id === "unread-shell" && item.type === "function_call_output"));
+		const transcript = await h.transcriptItems();
+		const summaries = transcript.filter((row) => row.type === "response_item" && row.payload.role === "assistant" && /SUMMARY_PART_ONE|SUMMARY_PART_TWO/.test(JSON.stringify(row.payload)));
+		assert.equal(summaries.length, 2, "both real summarizer outputs must be recorded");
+		assert.equal(transcript.filter((row) => row.type === "compacted").length, 1);
+		assert.match((await savedCheckpoint(h)).recovery, /STOCK_UNREAD_RESULT_83/);
+		await receipt(h, "multi-message-summary-recovery", { summaryMessages: 2, immediateUnreadRecovery: true });
+	});
+});

--- a/adapters/codex-posthorse/test/stock-v2.test.mjs
+++ b/adapters/codex-posthorse/test/stock-v2.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { RuntimeHarness, call, message, requestText, discoverNotes } from "./runtime-harness.mjs";
+
+const owner = "StockV2Owner47: preserve my exact request and unread output through ordinary remote compaction.";
+const unread = "STOCK_V2_UNREAD_RESULT_83";
+const automaticSummary = "SCRIPTED_V2_SUMMARY_21";
+const manualSummary = "SCRIPTED_V2_MANUAL_SUMMARY_61";
+const compaction = (encrypted_content) => ({ type: "compaction", encrypted_content });
+const sourceContext = (request, source) => request.body.input.filter((item) =>
+	item.type === "message" && item.role === "developer" && JSON.stringify(item).includes(`source=${source}`));
+const sessionHooks = (h, source) => h.events.filter((event) => event.method === "hook/completed" &&
+	event.params.run.eventName === "sessionStart" && event.params.run.entries.some((entry) => entry.text.includes(`source=${source}`)));
+
+async function checkpoint(h) {
+	const manifest = JSON.parse(await readFile(join(h.state, "threads", `${h.threadId}.json`), "utf8"));
+	return { path: manifest.checkpointPath, ...JSON.parse(await readFile(manifest.checkpointPath, "utf8")) };
+}
+
+async function checkpoints(h) {
+	const directory = join(h.state, "checkpoints", h.threadId);
+	return Promise.all((await readdir(directory)).map(async (file) => JSON.parse(await readFile(join(directory, file), "utf8"))));
+}
+
+async function usingV2Runtime(t, name, options, run) {
+	const h = await RuntimeHarness.create(name, { tokenBudget: false, localRecovery: false, stockRecovery: true, ...options });
+	t.diagnostic(`Retained V2 artifacts: ${h.root}`);
+	try {
+		await h.stop();
+		assert.match(h.config, /name = "Posthorse local test"/);
+		assert.match(h.config, /\[features.token_budget\]\nenabled = false/);
+		// This selects the stock V2 client path, while all requests remain on the loopback fixture.
+		h.config = h.config.replace('name = "Posthorse local test"', 'name = "OpenAI"')
+			.replace("[features]\n", "[features]\nremote_compaction_v2 = true\n");
+		assert.match(h.config, /base_url = "http:\/\/127\.0\.0\.1:\d+\/v1"/);
+		assert.match(h.config, /requires_openai_auth = false/);
+		assert.doesNotMatch(h.config, /local_recovery_hook|env_key|experimental_bearer_token/);
+		await writeFile(join(h.home, "config.toml"), h.config);
+		await h.start();
+		const account = await h.rpc("account/read", {});
+		assert.equal(account.requiresOpenaiAuth, false);
+		await writeFile(join(h.root, "account-read.json"), JSON.stringify(account, null, 2));
+		await h.thread();
+		const result = await run(h);
+		assert.ok(h.requests.every((request) => request.path === "/v1/responses"));
+		assert.equal(h.replies.length, 0);
+		assert.equal(h.providerError, undefined);
+		await writeFile(join(h.root, "acceptance.json"), JSON.stringify({
+			passed: true, runtime: process.env.POSTHORSE_CODEX_BIN ?? "codex", threadId: h.threadId,
+			transcript: h.transcript, source: "scripted loopback V2 provider; not live OpenAI",
+			codeMode: h.codeMode, modelRequests: h.requests.length, ...result,
+		}, null, 2) + "\n");
+	} finally {
+		await h.close();
+	}
+}
+
+test("stock V2 hooks recover unread output before continuation, survive restart, and retain manual summarization", async (t) => {
+	await usingV2Runtime(t, "stock-v2-auto-restart-manual", {}, async (h) => {
+		const turn = await h.turn(owner, [
+			{ items: [call("exec_command", { cmd: `printf '${unread}\\n'`, login: false }, "v2-unread-shell")], tokens: 9_500 },
+			{ items: [compaction(automaticSummary)] },
+			{ items: [message("V2 recovery continuation complete")] },
+		]);
+		assert.equal(turn.status, "completed");
+		assert.equal(h.requests.length, 3);
+		const summaryRequest = h.requests[1];
+		assert.equal(summaryRequest.body.input.filter((item) => item.type === "compaction_trigger").length, 1);
+		assert.match(requestText(summaryRequest), /STOCK_V2_UNREAD_RESULT_83/);
+		const continued = h.requests[2];
+		assert.equal(continued.body.input.find((item) => item.type === "compaction")?.encrypted_content, automaticSummary);
+		assert.ok(!continued.body.input.some((item) => item.type === "function_call_output" && item.call_id === "v2-unread-shell"));
+		const restored = sourceContext(continued, "compact");
+		assert.equal(restored.length, 1);
+		assert.match(JSON.stringify(restored), /StockV2Owner47/);
+		assert.match(JSON.stringify(restored), /STOCK_V2_UNREAD_RESULT_83/);
+		const compactHook = sessionHooks(h, "compact")[0];
+		assert.equal(compactHook.params.run.status, "completed");
+		assert.ok(compactHook.recordedAt >= summaryRequest.recordedAt);
+		assert.ok(compactHook.recordedAt <= continued.recordedAt);
+		const automaticCheckpoint = await checkpoint(h);
+		assert.equal(automaticCheckpoint.source, "compact");
+		const preCompactCheckpoint = (await checkpoints(h)).find((entry) => entry.trigger === "auto");
+		assert.ok(preCompactCheckpoint);
+		assert.ok(Date.parse(preCompactCheckpoint.createdAt) <= summaryRequest.recordedAt);
+		assert.match(automaticCheckpoint.recovery, /STOCK_V2_UNREAD_RESULT_83/);
+		const transcript = await h.transcriptItems();
+		const compacted = transcript.filter((row) => row.type === "compacted");
+		assert.equal(compacted.length, 1);
+		assert.match(JSON.stringify(compacted[0]), /SCRIPTED_V2_SUMMARY_21/);
+		assert.doesNotMatch(JSON.stringify(compacted[0].payload.replacement_history), /STOCK_V2_UNREAD_RESULT_83/);
+		assert.ok(continued.body.input.filter((item) => JSON.stringify(item).includes(unread)).every((item) =>
+			item.type === "message" && item.role === "developer" && item.internal_chat_message_metadata_passthrough?.content_item_kinds?.includes("hooks.additional_context")));
+		const outputIndex = transcript.findIndex((row) => row.type === "response_item" && row.payload.type === "function_call_output" && row.payload.call_id === "v2-unread-shell");
+		assert.ok(outputIndex >= 0);
+		const original = transcript[outputIndex];
+		const originalId = Number.isSafeInteger(original.ordinal) ? `ordinal:${original.ordinal}` : `line:${outputIndex + 1}`;
+		assert.match(automaticCheckpoint.recovery, new RegExp(originalId));
+		const launchesBeforeRestart = h.launches;
+		await h.restart();
+		assert.equal(h.launches, launchesBeforeRestart + 1);
+		const resumeFrom = h.requests.length;
+		const resumed = await h.turn("Resume the same V2 task and retrieve the original output by its record ID.", [
+			{ items: [discoverNotes()] },
+			{ items: [call("history", { op: "read", threadId: h.threadId, id: originalId }, "v2-read-original", "mcp__notes")] },
+			{ items: [message("V2 restart proof complete")] },
+		]);
+		assert.equal(resumed.status, "completed");
+		const resumedContext = sourceContext(h.requests[resumeFrom], "resume");
+		assert.equal(resumedContext.length, 1);
+		assert.match(JSON.stringify(resumedContext), /StockV2Owner47/);
+		assert.match(JSON.stringify(resumedContext), /STOCK_V2_UNREAD_RESULT_83/);
+		assert.equal(sessionHooks(h, "resume").at(-1).params.run.status, "completed");
+		const originalRead = h.requests.at(-1).body.input.find((item) => item.type === "function_call_output" && item.call_id === "v2-read-original");
+		assert.ok(originalRead);
+		assert.match(JSON.stringify(originalRead), /STOCK_V2_UNREAD_RESULT_83/);
+		assert.match(JSON.stringify(originalRead), new RegExp(originalId));
+		const manualFrom = h.requests.length;
+		await h.compact([{ items: [compaction(manualSummary)] }]);
+		assert.equal(h.requests.length, manualFrom + 1);
+		assert.equal(h.requests[manualFrom].body.input.filter((item) => item.type === "compaction_trigger").length, 1);
+		assert.equal((await h.transcriptItems()).filter((row) => row.type === "compacted").length, 2);
+		const manualTurn = await h.turn("Continue after manual V2 compaction.", [{ items: [message("V2 manual continuation complete")] }]);
+		assert.equal(manualTurn.status, "completed");
+		const manualContinuation = h.requests.at(-1);
+		assert.equal(manualContinuation.body.input.find((item) => item.type === "compaction")?.encrypted_content, manualSummary);
+		assert.equal(sourceContext(manualContinuation, "compact").length, 1);
+		assert.equal(sessionHooks(h, "compact").length, 2);
+		const manualCheckpoint = await checkpoint(h);
+		assert.equal(manualCheckpoint.source, "compact");
+		assert.ok((await checkpoints(h)).some((entry) => entry.trigger === "manual"));
+		assert.notEqual(manualCheckpoint.id, automaticCheckpoint.id);
+		assert.notEqual(manualCheckpoint.compactionId, automaticCheckpoint.compactionId);
+		return {
+			automaticV2Compactions: 1, manualV2Compactions: 1,
+			immediateSessionStartRecovery: true, unreadOutputOnlyRecoveredByHook: true,
+			originalRecordId: originalId, originalToolHistoryRead: true, fullAppServerRestart: true,
+			sameThreadResume: true, preservedCheckpoint: automaticCheckpoint.path,
+		};
+	});
+});
+
+test("stock V2 rebuilds a later missed checkpoint from original history and keeps that recovery after restart", async (t) => {
+	await usingV2Runtime(t, "stock-v2-stale-checkpoint", { hookFailure: "crash-after-checkpoint" }, async (h) => {
+		const first = await h.turn(owner, [
+			{ items: [call("exec_command", { cmd: `printf '${unread}\\n'`, login: false }, "first-v2-output")], tokens: 9_500 },
+			{ items: [compaction(automaticSummary)] },
+			{ items: [message("First V2 continuation complete")] },
+		]);
+		assert.equal(first.status, "completed");
+		const priorCheckpoint = await checkpoint(h);
+		const priorContents = await readFile(priorCheckpoint.path, "utf8");
+		const latestUnread = "STOCK_V2_LATEST_UNREAD_94";
+		const secondFrom = h.requests.length;
+		const eventsFrom = h.events.length;
+		const second = await h.turn("StockV2LatestOwner92: preserve this newer request and unread result.", [
+			{ items: [call("exec_command", { cmd: `printf '${latestUnread}\\n'`, login: false }, "latest-v2-output")], tokens: 9_500 },
+			{ items: [compaction("SCRIPTED_V2_SECOND_SUMMARY_52")] },
+			{ items: [message("Second V2 continuation complete")] },
+		]);
+		assert.equal(second.status, "completed");
+		assert.equal(h.requests.length, secondFrom + 3);
+		assert.equal(h.requests[secondFrom + 1].body.input.filter((item) => item.type === "compaction_trigger").length, 1);
+		const preCompactFailure = h.events.slice(eventsFrom).filter((event) => event.method === "hook/completed" &&
+			event.params.run.eventName === "preCompact" && event.params.run.status === "failed");
+		assert.equal(preCompactFailure.length, 1);
+		assert.match(JSON.stringify(preCompactFailure), /CONTROLLED_SECOND_CHECKPOINT_PROCESS_FAILURE/);
+		const continued = h.requests.at(-1);
+		const restored = sourceContext(continued, "compact");
+		assert.equal(restored.length, 1);
+		assert.match(JSON.stringify(restored), /StockV2LatestOwner92/);
+		assert.match(JSON.stringify(restored), /STOCK_V2_LATEST_UNREAD_94/);
+		assert.ok(!continued.body.input.some((item) => item.type === "function_call_output" && item.call_id === "latest-v2-output"));
+		assert.ok(continued.body.input.filter((item) => JSON.stringify(item).includes(latestUnread)).every((item) =>
+			item.type === "message" && item.role === "developer" && item.internal_chat_message_metadata_passthrough?.content_item_kinds?.includes("hooks.additional_context")));
+		const repaired = await checkpoint(h);
+		assert.equal(repaired.source, "compact");
+		assert.notEqual(repaired.compactionId, priorCheckpoint.compactionId);
+		assert.match(repaired.recovery, /STOCK_V2_LATEST_UNREAD_94/);
+		assert.equal(await readFile(priorCheckpoint.path, "utf8"), priorContents);
+		const transcript = await h.transcriptItems();
+		const compacted = transcript.filter((row) => row.type === "compacted");
+		assert.equal(compacted.length, 2);
+		assert.doesNotMatch(JSON.stringify(compacted.at(-1).payload.replacement_history), /STOCK_V2_LATEST_UNREAD_94/);
+		const outputIndex = transcript.findIndex((row) => row.type === "response_item" && row.payload.type === "function_call_output" && row.payload.call_id === "latest-v2-output");
+		assert.ok(outputIndex >= 0);
+		const original = transcript[outputIndex];
+		const originalId = Number.isSafeInteger(original.ordinal) ? `ordinal:${original.ordinal}` : `line:${outputIndex + 1}`;
+		assert.match(repaired.recovery, new RegExp(originalId));
+		const resumeFrom = h.requests.length;
+		await h.restart();
+		const resumed = await h.turn("Read the latest original result after restarting this V2 task.", [
+			{ items: [discoverNotes()] },
+			{ items: [call("history", { op: "read", threadId: h.threadId, id: originalId }, "v2-read-latest", "mcp__notes")] },
+			{ items: [message("Latest V2 recovery survived restart")] },
+		]);
+		assert.equal(resumed.status, "completed");
+		const resumedContext = sourceContext(h.requests[resumeFrom], "resume");
+		assert.equal(resumedContext.length, 1);
+		assert.match(JSON.stringify(resumedContext), /StockV2LatestOwner92/);
+		assert.match(JSON.stringify(resumedContext), /STOCK_V2_LATEST_UNREAD_94/);
+		const originalRead = h.requests.at(-1).body.input.find((item) => item.type === "function_call_output" && item.call_id === "v2-read-latest");
+		assert.ok(originalRead);
+		assert.match(JSON.stringify(originalRead), /STOCK_V2_LATEST_UNREAD_94/);
+		return {
+			automaticV2Compactions: 2, laterCheckpointProcessFailure: true,
+			latestUnreadOutputOnlyRecoveredByHook: true, staleCheckpointRebuilt: true,
+			originalCheckpointUnchanged: true, originalToolHistoryRead: true, sameThreadRestartRecovery: true,
+		};
+	});
+});

--- a/adapters/codex-posthorse/test/store.test.mjs
+++ b/adapters/codex-posthorse/test/store.test.mjs
@@ -78,6 +78,70 @@ test("interleaved sibling tool results survive but results followed by a new mod
 	assert.doesNotMatch((await f.store.checkpoint(f.hook)).recovery, /FIRST_SIBLING|SECOND_SIBLING|Consumed all results/);
 });
 
+test("stock repair rebuilds the latest boundary without treating summary messages as acknowledgement", async () => {
+	const f = await fixture([
+		user("ORIGINAL_REQUEST"), call("first"), output("first", "OLD_UNREAD"), tokenCount,
+	]);
+	await f.store.checkpoint(f.hook);
+	const append = [
+		assistant("FIRST_SUMMARY"), { type: "compacted", payload: { message: "FIRST_SUMMARY" } },
+		{ type: "event_msg", payload: { type: "item_completed", item: { type: "AgentMessage" } } },
+		assistant("Actual continuation"), user("NEW_REQUEST"),
+		call("latest"), output("latest", "LATEST_UNREAD"),
+		assistant("SUMMARY_PART_ONE"), assistant("SUMMARY_PART_TWO"),
+		{ type: "compacted", payload: { message: "SUMMARY_PART_TWO" } },
+		{ type: "event_msg", payload: { type: "item_completed", item: { type: "AgentMessage" } } },
+		assistant("Continuation after latest boundary"),
+	].map((row, index) => ({ ordinal: f.rows.length + index, ...row }));
+	const original = f.original + append.map(JSON.stringify).join("\n") + "\n";
+	await writeFile(f.transcript, original);
+	for (const source of ["compact", "resume"]) {
+		const hint = await createStore(f.stateDir).stockHint({ ...f.hook, source });
+		assert.match(hint, /ORIGINAL_REQUEST/);
+		assert.match(hint, /NEW_REQUEST/);
+		assert.match(hint, /LATEST_UNREAD/);
+		assert.doesNotMatch(hint, /OLD_UNREAD|SUMMARY_PART|FIRST_SUMMARY|Actual continuation|Continuation after/);
+		const manifest = JSON.parse(await readFile(join(f.stateDir, "threads", `${threadId}.json`), "utf8"));
+		const checkpoint = JSON.parse(await readFile(manifest.checkpointPath, "utf8"));
+		assert.equal(checkpoint.compactionId, `ordinal:${f.rows.length + 9}`);
+		assert.equal(checkpoint.throughOrdinal, f.rows.length + 8);
+	}
+	assert.equal(await readFile(f.transcript, "utf8"), original);
+	assert.equal((await readdir(join(f.stateDir, "checkpoints", threadId))).length, 3);
+});
+
+test("stock recovery honors normal message and plan completion in paginated and legacy history", async () => {
+	for (const completion of [
+		{ type: "item_completed", item: { type: "AgentMessage" } },
+		{ type: "item_completed", item: { type: "Plan" } },
+		{ type: "agent_message", message: "Actual legacy continuation" },
+	]) {
+		const f = await fixture([
+			user("OWNER_REQUEST"), call("old"), output("old", "ALREADY_CONSUMED"),
+			{ type: "event_msg", payload: completion }, assistant("Normal continuation"),
+			call("new"), output("new", "STILL_UNREAD"),
+			assistant("Summary without token usage"), { type: "compacted", payload: { message: "Summary without token usage" } },
+		], { ordinals: completion.type !== "agent_message" });
+		const hint = await f.store.stockHint({ ...f.hook, source: "compact" });
+		assert.match(hint, /OWNER_REQUEST/);
+		assert.match(hint, /STILL_UNREAD/);
+		assert.doesNotMatch(hint, /ALREADY_CONSUMED|Normal continuation|Summary without token usage/);
+		assert.equal(await readFile(f.transcript, "utf8"), f.original);
+	}
+});
+
+test("stock recovery stops on missing or unreadable boundaries instead of falling back to saved notes", async () => {
+	const f = await fixture([user("OLD_CHECKPOINT"), call("old"), output("old", "OLD_RESULT")]);
+	await f.store.checkpoint(f.hook);
+	const prior = await f.store.threadHint(threadId);
+	await assert.rejects(f.store.stockHint({ ...f.hook, source: "compact" }), /No completed compaction boundary/);
+	await writeFile(f.transcript, f.original + '{"type":"compacted","payload":');
+	for (const source of ["compact", "resume"]) {
+		await assert.rejects(f.store.stockHint({ ...f.hook, source }), /incomplete or invalid JSON/);
+	}
+	assert.equal(await f.store.threadHint(threadId), prior);
+});
+
 test("an aborted response with reasoning alone does not acknowledge prior tool results", async () => {
 	const f = await fixture([
 		user("Continue until verified"), call("pending"), output("pending", "KEEP_AFTER_FAILURE"), tokenCount,


### PR DESCRIPTION
## Summary

Add opt-in recovery hooks for ordinary compaction on the official signed Codex runtime. The existing native-fork path is unchanged; this does not install anything or replace the desktop executable.

Two distinct problems caused stale recovery: a later PreCompact hook crash left an older checkpoint that was reused, and ordinary summary messages were incorrectly treated as normal assistant acknowledgement of unread tool results.

The new stock SessionStart hook silently rebuilds recovery from original records before the latest saved compaction boundary, both immediately after compaction and on resume. Normal assistant-message and plan completion events mark acknowledged tool batches; summarizer text does not. Rebuilt checkpoints record their source and compaction ID. Missing or unreadable source records stop recovery instead of returning stale notes. Original transcripts and older checkpoints are retained.

## Verification

- Reproduced stale checkpoint reuse with the unchanged old characterization before the fix.
- Official-runtime stock recovery: 11 passed (9 ordinary protocol and 2 V2), zero failures/skips/TODOs. Includes repeated compaction after a hook crash, immediate unread-result recovery, full runtime restart, manual summaries, code mode, exact original-history retrieval, multiple summary messages, and nonzero/disabled/malformed/timed-out checkpoint hooks.
- The Linux CI stock-runtime job also passed. Its downloaded artifacts contain all 11 passing stock-recovery receipts; the three separate old token-budget characterization receipts remain false as expected.
- Adapter store/server tests: 17 passed.
- Pi tests: 39 passed; TypeScript check passed.
- Immutable patched-runtime strict suite: 22 passed, zero skips/TODOs.
- Existing stock characterization: 6 passed with its 3 expected unmet acceptance findings retained. Those token-budget-mode differences are not presented as full acceptance.
- actionlint and git diff whitespace checks passed. CI now downloads the official matching Linux code-mode helper and runs the stock recovery suite.
- Independent correctness, Ponytail, and UX review approved exact head `c46c90f4c3349b2a2030d17c74154a2607026e64`, with no material findings or unnecessary additions identified.

All runtime tests use scripted loopback model replies without credentials. The earlier user-operated signed-stock desktop proof showed recovery and native task-listing calls together before this fix; it is separate from this revision's runtime regression tests. Real-model/500k workloads and every desktop integration remain unverified. No new native binary, daily configuration change, or global installation is included.
