### PR TITLE
Fix the stock hook output limit in runtime tests

### DIFF
--- a/adapters/codex-posthorse/test/runtime-harness.mjs
+++ b/adapters/codex-posthorse/test/runtime-harness.mjs
@@ -148,7 +148,7 @@ export class RuntimeHarness {
 			preCompactConfig.trimEnd(),
 			'[[hooks.SessionStart]]',
 			'[[hooks.SessionStart.hooks]]', 'type = "command"', `command = ${quote(sessionCommand)}`,
-			...(this.stockRecovery ? ['additional_context_limit = 10000'] : []),
+			...(this.stockRecovery ? ['additionalContextLimit = 10000'] : []),
 			...(this.recordToolCompletions ? ['[[hooks.PostToolUse]]', '[[hooks.PostToolUse.hooks]]', 'type = "command"', `command = ${quote(completionCommand)}`] : []),
 			`[projects.${quote(this.cwd)}]`, 'trust_level = "trusted"',
 		].join("\n") + "\n";
@@ -158,6 +158,10 @@ export class RuntimeHarness {
 		await writeFile(join(this.root, "hooks-list.json"), JSON.stringify(listed, null, 2));
 		const hooks = listed.data.flatMap((entry) => entry.hooks ?? []);
 		if (!hooks.length) throw new Error(`No hooks discovered: ${JSON.stringify(listed)}`);
+		if (this.stockRecovery) {
+			const limit = hooks.find((hook) => hook.eventName === "sessionStart")?.additionalContextLimit;
+			if (limit !== 10_000) throw new Error(`Stock SessionStart additionalContextLimit must be 10000; received ${limit}`);
+		}
 		const recoveryHook = hooks.find((hook) => hook.eventName === "preCompact");
 		if (!recoveryHook) throw new Error("No PreCompact hook discovered");
 		await this.stop();


### PR DESCRIPTION
## Summary

Correct the stock-runtime test harness to write `additionalContextLimit`, the hook field Codex actually parses. The previous `additional_context_limit` spelling was ignored, leaving the default output limit active.

Check the parsed SessionStart limit returned by `hooks/list` before each stock test runs, so another ignored setting cannot silently pass.

Only the test harness changes. Production hooks, recovery storage, everyday settings, authentication, and the frozen live-trial adapter are unchanged.

## Verification

- Before the correction, the new check failed against the official runtime: expected 10000, received null. No model request was needed.
- After the correction, `hooks/list` reports `additionalContextLimit: 10000`.
- Official Codex 0.153.4 stock runtime suite: 11 passed, no skips.
- Adapter suite: 17 passed, no skips.
- JavaScript syntax and `git diff --check`: passed.

The runtime suite uses scripted loopback model responses, not real Astra inference or a fresh desktop trial. Follow-up to #16.
